### PR TITLE
reMarkable 2 support: windowed qtfb mode, arm32 fixes, one-command installer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ ureq = { version = "2.10", default-features = false, features = ["tls"] }
 [features]
 # Link libquill.so (vendor e-ink engine C ABI) for full-takeover mode.
 takeover = []
+# Target the reMarkable 2 (1404x1872, rotated wacom digitizer, 32-bit ARM).
+# Windowed (qtfb/AppLoad) only — takeover is Paper Pro-specific.
+rm2 = []
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -235,7 +235,10 @@ rustup target add armv7-unknown-linux-musleabihf   # once; needs zig + cargo-zig
 
 Full walkthrough, manual steps, and troubleshooting:
 **[docs/rm2-setup.md](docs/rm2-setup.md)**. The rM2 runs in windowed
-(AppLoad/qtfb) mode only — the takeover engine is Paper Pro-specific.
+(AppLoad/qtfb) mode only — the takeover engine is Paper Pro-specific, so
+your own ink echoes with visible latency (tunable via `RIDDLE_FLUSH_MS`
+and `RIDDLE_IDLE_MS` in `oracle.env`, but the compositor pipeline sets a
+floor). Treat it as a delightful demo, not a notes replacement.
 
 ## What leaves the device
 

--- a/README.md
+++ b/README.md
@@ -223,18 +223,19 @@ riddle dies uncleanly. If anything wedges:
 
 ### reMarkable 2 (windowed only)
 
-The rM2 build targets 32-bit ARM and the rM2's 1404×1872 panel, and runs in
-windowed (AppLoad/qtfb) mode only — the takeover engine is Paper Pro-specific.
-Requires [xovi + AppLoad](https://github.com/asivery/rm-appload) on the device.
+The rM2 needs **no developer mode** — SSH is built in (password under
+Settings → Help → Copyrights → GPLv3 Compliance). One command installs
+everything: xovi, AppLoad, persistence, riddle, and your oracle key:
 
 ```sh
-rustup target add armv7-unknown-linux-musleabihf
-./build-rm2.sh     # needs cargo-zigbuild + zig; emits dist/rm2/riddle/
-scp -O -r dist/rm2/riddle root@10.11.99.1:/home/root/xovi/exthome/appload/
+rustup target add armv7-unknown-linux-musleabihf   # once; needs zig + cargo-zigbuild
+./build-rm2.sh
+./scripts/install-rm2.sh        # USB; or RM_HOST=<tablet-ip> for Wi-Fi
 ```
 
-Then add your key in `oracle.env` as above, Reload in AppLoad, and open
-**The Diary**. Tested on reMarkable 2, OS 3.x.
+Full walkthrough, manual steps, and troubleshooting:
+**[docs/rm2-setup.md](docs/rm2-setup.md)**. The rM2 runs in windowed
+(AppLoad/qtfb) mode only — the takeover engine is Paper Pro-specific.
 
 ## What leaves the device
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,21 @@ diary without leaving it. The unit's stop hook restarts xochitl even if
 riddle dies uncleanly. If anything wedges:
 `ssh root@10.11.99.1 'systemctl start xochitl'`.
 
+### reMarkable 2 (windowed only)
+
+The rM2 build targets 32-bit ARM and the rM2's 1404×1872 panel, and runs in
+windowed (AppLoad/qtfb) mode only — the takeover engine is Paper Pro-specific.
+Requires [xovi + AppLoad](https://github.com/asivery/rm-appload) on the device.
+
+```sh
+rustup target add armv7-unknown-linux-musleabihf
+./build-rm2.sh     # needs cargo-zigbuild + zig; emits dist/rm2/riddle/
+scp -O -r dist/rm2/riddle root@10.11.99.1:/home/root/xovi/exthome/appload/
+```
+
+Then add your key in `oracle.env` as above, Reload in AppLoad, and open
+**The Diary**. Tested on reMarkable 2, OS 3.x.
+
 ## What leaves the device
 
 - Each committed page is rasterized to a small grayscale PNG and sent to the

--- a/build-rm2.sh
+++ b/build-rm2.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Cross-build riddle for the reMarkable 2 (windowed/qtfb mode only) and
+# assemble a ready-to-scp AppLoad bundle in dist/rm2/riddle/.
+#
+# The rM2 is 32-bit ARM. We target musl and link statically so the binary is
+# independent of the device's (old) glibc. Requires cargo-zigbuild + zig:
+#   rustup target add armv7-unknown-linux-musleabihf
+#   brew install zig cargo-zigbuild        # or: cargo install cargo-zigbuild
+set -e
+cd "$(dirname "$0")"
+
+TARGET=armv7-unknown-linux-musleabihf
+export RUSTFLAGS="-C target-feature=+crt-static"
+
+cargo zigbuild --release --target $TARGET --features rm2 "$@"
+
+OUT=target/$TARGET/release
+DIST=dist/rm2/riddle
+rm -rf "$DIST"
+mkdir -p "$DIST"
+
+cp "$OUT/riddle" "$DIST/riddle"
+cp scripts/appload-launch-windowed.sh "$DIST/appload-launch.sh"
+chmod +x "$DIST/riddle" "$DIST/appload-launch.sh"
+cp icon.png oracle.env.example "$DIST/"
+cat > "$DIST/external.manifest.json" <<'EOF'
+{
+  "name": "The Diary",
+  "application": "appload-launch.sh",
+  "qtfb": true
+}
+EOF
+
+echo
+echo "Bundle ready: $DIST"
+echo "Install:  scp -O -r dist/rm2/riddle root@10.11.99.1:/home/root/xovi/exthome/appload/"
+echo "Then create oracle.env in that folder with your RIDDLE_OPENAI_KEY."

--- a/build-rm2.sh
+++ b/build-rm2.sh
@@ -9,6 +9,15 @@
 set -e
 cd "$(dirname "$0")"
 
+# Homebrew installs rustup keg-only (not symlinked into PATH); find it anyway.
+if ! command -v cargo >/dev/null 2>&1; then
+    for p in /opt/homebrew/opt/rustup/bin "$HOME/.cargo/bin"; do
+        [ -x "$p/cargo" ] && PATH="$p:$PATH" && break
+    done
+fi
+command -v cargo >/dev/null 2>&1 || {
+    echo "cargo not found — install Rust first: https://rustup.rs" >&2; exit 1; }
+
 TARGET=armv7-unknown-linux-musleabihf
 export RUSTFLAGS="-C target-feature=+crt-static"
 

--- a/docs/rm2-setup.md
+++ b/docs/rm2-setup.md
@@ -1,83 +1,100 @@
 # riddle on the reMarkable 2 — setup from zero
 
 The rM2 needs no "developer mode": SSH as root is built into every unit.
-You need: the tablet, its USB-C cable, and ~20 minutes.
+You need: the tablet, its USB-C cable, and ~15 minutes.
 
-## 1. Get SSH access
+## Quick path (one command)
 
-1. On the tablet: **Settings → Help → Copyrights and licenses → GPLv3 Compliance**.
-   The password and IP (`10.11.99.1`) are shown at the bottom.
-2. Plug the tablet into your computer over USB.
-3. `ssh root@10.11.99.1` — enter that password.
-4. Recommended: install your key so future steps don't prompt:
-   `ssh-copy-id root@10.11.99.1`
-
-> **Keep SSH working.** It is the escape hatch for everything below. Note the
-> password somewhere safe. reMarkable OS updates can remove third-party
-> software (xovi, AppLoad, riddle) — they are reinstallable, but keep this in
-> mind before accepting an update.
-
-## 2. Install xovi + AppLoad
-
-riddle runs as an [AppLoad](https://github.com/asivery/rm-appload) app inside
-xochitl via the [xovi](https://github.com/asivery/xovi) extension framework.
-The maintained path is asivery's installer — follow the AppLoad README for the
-one-command install appropriate to your OS version. After install, a launcher
-chip appears in the tablet's UI; tap it to see the AppLoad screen.
-
-## 3. Build and install riddle (from a computer)
+1. On the tablet, read the root password: **Settings → Help → Copyrights and
+   licenses → GPLv3 Compliance** (bottom of the page; the IP shown is
+   `10.11.99.1`). Note the password somewhere safe.
+2. Plug the tablet in over USB.
+3. Build and install everything:
 
 ```sh
-rustup target add armv7-unknown-linux-musleabihf
-cd riddle && ./build-rm2.sh
-scp -O -r dist/rm2/riddle root@10.11.99.1:/home/root/xovi/exthome/appload/
+rustup target add armv7-unknown-linux-musleabihf   # once; needs zig + cargo-zigbuild
+cd riddle && ./build-rm2.sh && cd ..
+./scripts/install-rm2.sh
 ```
 
-## 4. Add the oracle key
+The installer connects over SSH (asking for that password once, then installing
+your key), confirms the device is an rM2, installs
+[xovi](https://github.com/asivery/xovi) +
+[AppLoad](https://github.com/asivery/rm-appload) from their official arm32
+releases, adds power-button persistence via
+[xovi-tripletap](https://github.com/rmitchellscott/xovi-tripletap)
+(triple-press = toggle xovi), copies the riddle bundle, prompts for your API
+key, and verifies the oracle end-to-end.
 
-```sh
-ssh root@10.11.99.1
-cd /home/root/xovi/exthome/appload/riddle
-cp oracle.env.example oracle.env
-vi oracle.env
+Then on the tablet: open **AppLoad → The Diary**, write, rest the pen ~3 s.
+
+> ⚠️ Everything here is reversible (`ssh root@10.11.99.1
+> /home/root/xovi/stock` or a reboot returns the stock UI), but reMarkable OS
+> updates can remove xovi/AppLoad/riddle — reinstallable by re-running the
+> installer. Keep the SSH password: it is your escape hatch.
+
+### If SSH says `Their offer: ssh-rsa`
+
+The rM2's SSH server only speaks the legacy `ssh-rsa` algorithm, which modern
+OpenSSH clients refuse by default. The installer handles this for its own
+connections; for your own `ssh`/`scp` sessions, add to `~/.ssh/config`:
+
+```
+Host remarkable rm2 10.11.99.1
+  HostName 10.11.99.1
+  User root
+  HostKeyAlgorithms +ssh-rsa
+  PubkeyAcceptedAlgorithms +ssh-rsa
 ```
 
-For OpenRouter:
+## The oracle key
+
+Any OpenAI-compatible, vision-capable endpoint works. The installer writes
+`oracle.env` for you; to change it later, edit
+`/home/root/xovi/exthome/appload/riddle/oracle.env` on the tablet. OpenRouter
+example:
 
 ```sh
 RIDDLE_OPENAI_KEY=sk-or-v1-...
 RIDDLE_OPENAI_BASE=https://openrouter.ai/api/v1
-RIDDLE_OPENAI_MODEL=openai/gpt-4o-mini    # any vision-capable model
+RIDDLE_OPENAI_MODEL=openai/gpt-4o-mini
 ```
 
-Verify before ever opening the diary (prints the streamed reply, no display
-needed) — run on the tablet:
+Test it any time (tablet must be on Wi-Fi — USB gives it no internet):
 
 ```sh
-cd /home/root/xovi/exthome/appload/riddle
-set -a; . ./oracle.env; set +a
-./riddle --oracle-test path/to/any-handwriting.png
+ssh rm2 'cd /home/root/xovi/exthome/appload/riddle && \
+  set -a && . ./oracle.env && set +a && ./riddle --oracle-test icon.png'
 ```
 
-The tablet must be on Wi-Fi (USB alone gives the tablet no internet).
+## Manual path (what the installer does, step by step)
 
-## 5. Run
+If you prefer to run each step yourself:
 
-AppLoad → **Reload** → **The Diary**. Write something, rest the pen ~3 s,
-and watch the page drink your ink.
+1. **xovi** — grab `xovi-arm32.tar.gz` from
+   [rm-xovi-extensions releases](https://github.com/asivery/rm-xovi-extensions/releases/latest)
+   (it contains the loader, start/stop scripts, and qt-resource-rebuilder), and
+   extract on the tablet: `tar -xzf xovi.tar.gz -C /home/root`.
+2. **AppLoad** — grab `appload-arm32.zip` from
+   [rm-appload releases](https://github.com/asivery/rm-appload/releases/latest).
+   `appload.so` goes to `/home/root/xovi/extensions.d/`; the `shims/` folder
+   goes to `/home/root/xovi/exthome/appload/shims/` (not extensions.d).
+3. **Persistence** — on the tablet:
+   `wget -qO- https://raw.githubusercontent.com/rmitchellscott/xovi-tripletap/main/install.sh | bash`
+4. **riddle** — `scp -O -r dist/rm2/riddle root@10.11.99.1:/home/root/xovi/exthome/appload/`,
+   then create `oracle.env` in that folder (see above).
+5. **Start** — `/home/root/xovi/start` on the tablet (or triple-press power).
 
 ## Troubleshooting
 
-- **Ink lands in the wrong place / mirrored** — the raw digitizer transform
-  is off for your unit. Relaunch with the qtfb fallback to compare:
-  temporarily rename the wacom grab away by launching `riddle` with the pen
-  device busy, or report it upstream; the qtfb pen path (used automatically
-  when the raw device can't be opened) is always correctly mapped.
-- **"qtfb server rejected init"** — AppLoad missing or old; reinstall/update
-  AppLoad, then Reload.
-- **No reply, blot pulses forever** — oracle problem: re-run `--oracle-test`;
-  check Wi-Fi, key, and that the model chosen supports images.
-- **Tablet acting up after experiments** — `ssh root@10.11.99.1 'systemctl
-  restart xochitl'` restores the stock UI; worst case a reboot (hold power
-  ~10 s) returns everything to normal. riddle in windowed mode never stops
-  xochitl, so the blast radius is small.
+- **Ink lands in the wrong place / mirrored** — the raw digitizer transform is
+  off for your unit. The qtfb pen fallback (used automatically when the raw
+  device can't be opened) is always correctly mapped — compare against it and
+  open an issue with what you see.
+- **"qtfb server rejected init"** — AppLoad missing or old; re-run the
+  installer, then Reload in AppLoad.
+- **No reply, ink blot pulses forever** — oracle problem: re-run
+  `--oracle-test`; check Wi-Fi, key, and that the model supports images.
+- **Tablet acting up** — `ssh rm2 'systemctl restart xochitl'` restores the
+  stock UI; worst case hold power ~10 s to reboot. riddle in windowed mode
+  never stops xochitl, so the blast radius is small.

--- a/docs/rm2-setup.md
+++ b/docs/rm2-setup.md
@@ -33,17 +33,27 @@ Then on the tablet: open **AppLoad → The Diary**, write, rest the pen ~3 s.
 > updates can remove xovi/AppLoad/riddle — reinstallable by re-running the
 > installer. Keep the SSH password: it is your escape hatch.
 
-### If SSH says `Their offer: ssh-rsa`
+### If SSH won't connect
 
-The rM2's SSH server only speaks the legacy `ssh-rsa` algorithm, which modern
-OpenSSH clients refuse by default. The installer handles this for its own
-connections; for your own `ssh`/`scp` sessions, add to `~/.ssh/config`:
+Two rM2 SSH quirks, both handled by the installer for its own connections.
+For your own `ssh`/`scp` sessions:
+
+- **`Connection closed by 10.11.99.1 port 22`** — the rM2's dropbear (OS 3.x)
+  has a broken RSA host-key path: it hangs up whenever RSA is negotiated,
+  though ed25519 works fine. A stale `ssh-rsa` entry for `10.11.99.1` in your
+  `~/.ssh/known_hosts` (from an older device or firmware) forces your client
+  to request RSA and triggers exactly this. Fix:
+  `ssh-keygen -R 10.11.99.1`, then connect again.
+- **`no matching host key type found. Their offer: ssh-rsa`** — older firmware
+  offers only legacy `ssh-rsa`, which modern OpenSSH refuses by default.
+
+This `~/.ssh/config` block covers both:
 
 ```
 Host remarkable rm2 10.11.99.1
   HostName 10.11.99.1
   User root
-  HostKeyAlgorithms +ssh-rsa
+  HostKeyAlgorithms ssh-ed25519,ssh-rsa
   PubkeyAcceptedAlgorithms +ssh-rsa
 ```
 

--- a/docs/rm2-setup.md
+++ b/docs/rm2-setup.md
@@ -1,0 +1,83 @@
+# riddle on the reMarkable 2 — setup from zero
+
+The rM2 needs no "developer mode": SSH as root is built into every unit.
+You need: the tablet, its USB-C cable, and ~20 minutes.
+
+## 1. Get SSH access
+
+1. On the tablet: **Settings → Help → Copyrights and licenses → GPLv3 Compliance**.
+   The password and IP (`10.11.99.1`) are shown at the bottom.
+2. Plug the tablet into your computer over USB.
+3. `ssh root@10.11.99.1` — enter that password.
+4. Recommended: install your key so future steps don't prompt:
+   `ssh-copy-id root@10.11.99.1`
+
+> **Keep SSH working.** It is the escape hatch for everything below. Note the
+> password somewhere safe. reMarkable OS updates can remove third-party
+> software (xovi, AppLoad, riddle) — they are reinstallable, but keep this in
+> mind before accepting an update.
+
+## 2. Install xovi + AppLoad
+
+riddle runs as an [AppLoad](https://github.com/asivery/rm-appload) app inside
+xochitl via the [xovi](https://github.com/asivery/xovi) extension framework.
+The maintained path is asivery's installer — follow the AppLoad README for the
+one-command install appropriate to your OS version. After install, a launcher
+chip appears in the tablet's UI; tap it to see the AppLoad screen.
+
+## 3. Build and install riddle (from a computer)
+
+```sh
+rustup target add armv7-unknown-linux-musleabihf
+cd riddle && ./build-rm2.sh
+scp -O -r dist/rm2/riddle root@10.11.99.1:/home/root/xovi/exthome/appload/
+```
+
+## 4. Add the oracle key
+
+```sh
+ssh root@10.11.99.1
+cd /home/root/xovi/exthome/appload/riddle
+cp oracle.env.example oracle.env
+vi oracle.env
+```
+
+For OpenRouter:
+
+```sh
+RIDDLE_OPENAI_KEY=sk-or-v1-...
+RIDDLE_OPENAI_BASE=https://openrouter.ai/api/v1
+RIDDLE_OPENAI_MODEL=openai/gpt-4o-mini    # any vision-capable model
+```
+
+Verify before ever opening the diary (prints the streamed reply, no display
+needed) — run on the tablet:
+
+```sh
+cd /home/root/xovi/exthome/appload/riddle
+set -a; . ./oracle.env; set +a
+./riddle --oracle-test path/to/any-handwriting.png
+```
+
+The tablet must be on Wi-Fi (USB alone gives the tablet no internet).
+
+## 5. Run
+
+AppLoad → **Reload** → **The Diary**. Write something, rest the pen ~3 s,
+and watch the page drink your ink.
+
+## Troubleshooting
+
+- **Ink lands in the wrong place / mirrored** — the raw digitizer transform
+  is off for your unit. Relaunch with the qtfb fallback to compare:
+  temporarily rename the wacom grab away by launching `riddle` with the pen
+  device busy, or report it upstream; the qtfb pen path (used automatically
+  when the raw device can't be opened) is always correctly mapped.
+- **"qtfb server rejected init"** — AppLoad missing or old; reinstall/update
+  AppLoad, then Reload.
+- **No reply, blot pulses forever** — oracle problem: re-run `--oracle-test`;
+  check Wi-Fi, key, and that the model chosen supports images.
+- **Tablet acting up after experiments** — `ssh root@10.11.99.1 'systemctl
+  restart xochitl'` restores the stock UI; worst case a reboot (hold power
+  ~10 s) returns everything to normal. riddle in windowed mode never stops
+  xochitl, so the blast radius is small.

--- a/oracle.env.example
+++ b/oracle.env.example
@@ -56,3 +56,14 @@ RIDDLE_OPENAI_KEY=sk-your-key-here
 # --- feel tuning (windowed/qtfb mode) — defaults shown ---
 # RIDDLE_FLUSH_MS=12    # ink update batching; lower = snappier, more CPU
 # RIDDLE_IDLE_MS=2800   # pen-rest time before the diary drinks the page
+# RIDDLE_IDLE_MS=0 disables auto-send entirely (the send rule is then the
+# only trigger).
+# RIDDLE_REPLY_WIDTH=4  # reply pen thickness; thicker reads darker on fast waveforms
+
+# The reply hand: any TTF/OTF dropped next to the binary (or an absolute
+# path). Unset = the embedded Dancing Script.
+# RIDDLE_FONT_FILE=Lora.ttf
+
+# The spirit: put a system prompt in persona.txt next to the binary (or point
+# RIDDLE_PERSONA_FILE at one) to replace Tom with any assistant you like.
+# RIDDLE_PERSONA_FILE=persona.txt

--- a/oracle.env.example
+++ b/oracle.env.example
@@ -52,3 +52,7 @@ RIDDLE_OPENAI_KEY=sk-your-key-here
 # Keep the committed page at /tmp/riddle-page.png after each turn instead of
 # deleting it once the oracle has read it. Handy with `riddle --oracle-test`.
 # RIDDLE_KEEP_PAGE=1
+
+# --- feel tuning (windowed/qtfb mode) — defaults shown ---
+# RIDDLE_FLUSH_MS=12    # ink update batching; lower = snappier, more CPU
+# RIDDLE_IDLE_MS=2800   # pen-rest time before the diary drinks the page

--- a/scripts/appload-launch-windowed.sh
+++ b/scripts/appload-launch-windowed.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# AppLoad entry point for windowed (qtfb) mode — used on the reMarkable 2,
+# where the takeover backend does not exist. AppLoad sets QTFB_KEY for us;
+# riddle sees it and picks the qtfb display backend.
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+# Oracle config: put your API key in oracle.env next to this script.
+if [ -f "$HERE/oracle.env" ]; then
+    set -a; . "$HERE/oracle.env"; set +a
+fi
+
+cd "$HERE"
+HOME=/home/root exec "$HERE/riddle"

--- a/scripts/install-rm2.sh
+++ b/scripts/install-rm2.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# riddle rM2 installer — one command from zero to the diary on a reMarkable 2.
+#
+#   Usage:   ./scripts/install-rm2.sh                    # USB (10.11.99.1)
+#            RM_HOST=192.168.1.42 ./scripts/install-rm2.sh   # over Wi-Fi
+#
+# Unlike the Paper Pro, the rM2 needs NO developer mode: SSH is stock. Find the
+# root password on the tablet under Settings > Help > Copyrights and licenses >
+# GPLv3 Compliance, then run this. It installs, over SSH:
+#   1. your SSH key (so you type that password once)
+#   2. xovi + AppLoad (arm32, from asivery's official releases)
+#   3. xovi-tripletap persistence (triple-press power = toggle xovi)
+#   4. the riddle bundle from dist/rm2/riddle (build-rm2.sh output)
+# and asks for your API key to write oracle.env.
+#
+# Everything is reversible: `ssh root@10.11.99.1 /home/root/xovi/stock`
+# returns the stock UI; a reboot does too.
+set -euo pipefail
+
+RM_HOST="${RM_HOST:-10.11.99.1}"
+XOVI_BUNDLE_TAG="${XOVI_BUNDLE_TAG:-v19-23052026}"   # asivery/rm-xovi-extensions
+APPLOAD_TAG="${APPLOAD_TAG:-v0.5.3}"                  # asivery/rm-appload
+XOVI_BUNDLE_URL="https://github.com/asivery/rm-xovi-extensions/releases/download/${XOVI_BUNDLE_TAG}/xovi-arm32.tar.gz"
+APPLOAD_URL="https://github.com/asivery/rm-appload/releases/download/${APPLOAD_TAG}/appload-arm32.zip"
+TRIPLETAP_INSTALL_URL="https://raw.githubusercontent.com/rmitchellscott/xovi-tripletap/main/install.sh"
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+BUNDLE="$HERE/dist/rm2/riddle"
+
+say()  { printf '\033[1m== %s\033[0m\n' "$*"; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# The rM2's SSH server only offers legacy ssh-rsa; modern OpenSSH clients
+# refuse it by default ("no matching host key type found. Their offer: ssh-rsa").
+SSH_OPTS=(-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa)
+rm_ssh() { ssh "${SSH_OPTS[@]}" "root@$RM_HOST" "$@"; }
+rm_scp() { scp -O "${SSH_OPTS[@]}" "$@"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- 0. riddle bundle must exist locally -------------------------------------
+[ -x "$BUNDLE/riddle" ] || die "no rM2 bundle at $BUNDLE — run riddle/build-rm2.sh first"
+
+# --- 1. reach the tablet, install our key, confirm it is an rM2 --------------
+say "Connecting to $RM_HOST (the tablet will ask for its root password)"
+if ! rm_ssh true 2>/dev/null; then
+    [ -f "$HOME/.ssh/id_ed25519.pub" ] || [ -f "$HOME/.ssh/id_rsa.pub" ] \
+        || die "no SSH key found; create one with: ssh-keygen -t ed25519"
+    ssh-copy-id "${SSH_OPTS[@]}" "root@$RM_HOST" || die "cannot reach root@$RM_HOST"
+fi
+MACHINE="$(rm_ssh 'cat /sys/devices/soc0/machine 2>/dev/null' || true)"
+case "$MACHINE" in
+    "reMarkable 2.0") say "Found a reMarkable 2" ;;
+    *) die "this installer is rM2-only; device says: '${MACHINE:-unknown}'" ;;
+esac
+
+# --- 2. xovi (loader + scripts + qt-resource-rebuilder) ----------------------
+say "Installing xovi"
+curl -fL --retry 3 -o "$WORK/xovi.tar.gz" "$XOVI_BUNDLE_URL"
+rm_scp "$WORK/xovi.tar.gz" "root@$RM_HOST:/tmp/xovi.tar.gz"
+rm_ssh 'tar -xzf /tmp/xovi.tar.gz -C /home/root && rm -f /tmp/xovi.tar.gz'
+# Activate the message broker if this bundle ships it inactive (harmless).
+rm_ssh '[ -f /home/root/xovi/inactive-extensions/xovi-message-broker.so ] && \
+        mv -f /home/root/xovi/inactive-extensions/xovi-message-broker.so \
+              /home/root/xovi/extensions.d/ 2>/dev/null; true'
+
+# --- 3. AppLoad ---------------------------------------------------------------
+say "Installing the AppLoad launcher"
+curl -fL --retry 3 -o "$WORK/appload.zip" "$APPLOAD_URL"
+rm_scp "$WORK/appload.zip" "root@$RM_HOST:/tmp/appload.zip"
+# Only appload.so is a xovi extension; the qtfb shims live under AppLoad's own
+# exthome dir (NOT extensions.d, or xovi tries to load them and errors).
+rm_ssh 'cd /tmp && rm -rf appload-unz && mkdir appload-unz && \
+        unzip -oq appload.zip -d appload-unz && \
+        cp -f appload-unz/appload.so /home/root/xovi/extensions.d/ && \
+        mkdir -p /home/root/xovi/exthome/appload && \
+        if [ -d appload-unz/shims ]; then cp -rf appload-unz/shims /home/root/xovi/exthome/appload/; fi && \
+        if [ -d appload-unz/exthome ]; then cp -rf appload-unz/exthome/. /home/root/xovi/exthome/; fi && \
+        rm -rf appload-unz appload.zip'
+
+# qt-resource-rebuilder wants a per-OS-version hashtable; AppLoad itself does
+# not need it, so best-effort only.
+rm_ssh 'test -x /home/root/xovi/rebuild_hashtable && /home/root/xovi/rebuild_hashtable </dev/null' \
+    || echo "   (hashtable rebuild skipped — fine for riddle)"
+
+# --- 4. persistence (triple-press the power button to toggle xovi) -----------
+say "Installing xovi-tripletap persistence"
+rm_ssh "wget -qO- '$TRIPLETAP_INSTALL_URL' | bash" \
+    || echo "   tripletap didn't install; start xovi manually: ssh root@$RM_HOST /home/root/xovi/start"
+
+# --- 5. riddle ----------------------------------------------------------------
+say "Installing riddle"
+rm_ssh 'mkdir -p /home/root/xovi/exthome/appload'
+rm_scp -r "$BUNDLE" "root@$RM_HOST:/home/root/xovi/exthome/appload/"
+
+if ! rm_ssh 'test -f /home/root/xovi/exthome/appload/riddle/oracle.env'; then
+    printf 'API key for the oracle (OpenAI/OpenRouter/compatible; empty to skip): '
+    read -r KEY
+    if [ -n "$KEY" ]; then
+        printf 'API base URL [https://api.openai.com/v1]: '
+        read -r BASE; BASE="${BASE:-https://api.openai.com/v1}"
+        printf 'Vision model [gpt-4o-mini]: '
+        read -r MODEL; MODEL="${MODEL:-gpt-4o-mini}"
+        rm_ssh "cat > /home/root/xovi/exthome/appload/riddle/oracle.env" <<EOF
+RIDDLE_OPENAI_KEY=$KEY
+RIDDLE_OPENAI_BASE=$BASE
+RIDDLE_OPENAI_MODEL=$MODEL
+EOF
+        say "Verifying the oracle (needs tablet Wi-Fi)"
+        rm_ssh 'cd /home/root/xovi/exthome/appload/riddle && set -a && . ./oracle.env && set +a && \
+                ./riddle --oracle-test icon.png' \
+            || echo "   oracle test failed — check Wi-Fi/key/model, then re-run: riddle --oracle-test"
+    fi
+fi
+
+# --- 6. start xovi now --------------------------------------------------------
+say "Starting xovi"
+rm_ssh 'systemd-run --unit=xovi-firststart --collect --service-type=oneshot /home/root/xovi/start 2>/dev/null' \
+    || echo "   couldn't start now — triple-press the power button, or reboot"
+
+cat <<EOF
+
+  Done. On the tablet, open AppLoad and tap "The Diary".
+  Write something, rest the pen ~3 s, and watch the page drink your ink.
+
+  Toggle xovi:   triple-press the power button
+  Stock UI:      ssh root@$RM_HOST /home/root/xovi/stock   (or reboot)
+EOF

--- a/scripts/install-rm2.sh
+++ b/scripts/install-rm2.sh
@@ -37,23 +37,32 @@ die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 #    exactly this; clear it with: ssh-keygen -R 10.11.99.1
 #  - older firmware offers only ssh-rsa, which modern clients refuse by
 #    default — so keep ssh-rsa as an accepted fallback.
-SSH_OPTS=(-o HostKeyAlgorithms=ssh-ed25519,ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa)
-rm_ssh() { ssh "${SSH_OPTS[@]}" "root@$RM_HOST" "$@"; }
-rm_scp() { scp -O "${SSH_OPTS[@]}" "$@"; }
-
 WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
+
+# One multiplexed SSH connection for the whole install (ControlMaster): the
+# password is typed at most once; every later command and copy rides it.
+SSH_OPTS=(-o HostKeyAlgorithms=ssh-ed25519,ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa
+          -o ControlMaster=auto -o "ControlPath=$WORK/ssh-ctrl" -o ControlPersist=300)
+rm_ssh() { ssh -n "${SSH_OPTS[@]}" "root@$RM_HOST" "$@"; }
+rm_ssh_stdin() { ssh "${SSH_OPTS[@]}" "root@$RM_HOST" "$@"; }
+rm_scp() { scp -O "${SSH_OPTS[@]}" "$@"; }
+cleanup() { ssh "${SSH_OPTS[@]}" -O exit "root@$RM_HOST" 2>/dev/null; rm -rf "$WORK"; }
+trap cleanup EXIT
 
 # --- 0. riddle bundle must exist locally -------------------------------------
 [ -x "$BUNDLE/riddle" ] || die "no rM2 bundle at $BUNDLE — run riddle/build-rm2.sh first"
 
 # --- 1. reach the tablet, install our key, confirm it is an rM2 --------------
-say "Connecting to $RM_HOST (the tablet will ask for its root password)"
-if ! rm_ssh true 2>/dev/null; then
+# BatchMode probe: succeeds only with key auth, so a password-only tablet
+# (e.g. fresh from a factory reset) correctly falls through to ssh-copy-id.
+if ! ssh -n "${SSH_OPTS[@]}" -o BatchMode=yes -o ConnectTimeout=5 "root@$RM_HOST" true 2>/dev/null; then
+    say "Installing your SSH key (type the tablet's password once — Settings > Help > GPLv3)"
     [ -f "$HOME/.ssh/id_ed25519.pub" ] || [ -f "$HOME/.ssh/id_rsa.pub" ] \
         || die "no SSH key found; create one with: ssh-keygen -t ed25519"
     ssh-copy-id "${SSH_OPTS[@]}" "root@$RM_HOST" || die "cannot reach root@$RM_HOST"
 fi
+echo "   Heads-up: one install step restarts the tablet UI. If your tablet"
+echo "   has a PIN, unlock it when the lock screen appears mid-install."
 MACHINE="$(rm_ssh 'cat /sys/devices/soc0/machine 2>/dev/null' || true)"
 case "$MACHINE" in
     "reMarkable 2.0") say "Found a reMarkable 2" ;;
@@ -103,11 +112,17 @@ if ! rm_ssh 'test -f /home/root/xovi/exthome/appload/riddle/oracle.env'; then
     printf 'API key for the oracle (OpenAI/OpenRouter/compatible; empty to skip): '
     read -r KEY
     if [ -n "$KEY" ]; then
-        printf 'API base URL [https://api.openai.com/v1]: '
-        read -r BASE; BASE="${BASE:-https://api.openai.com/v1}"
-        printf 'Vision model [gpt-4o-mini]: '
-        read -r MODEL; MODEL="${MODEL:-gpt-4o-mini}"
-        rm_ssh "cat > /home/root/xovi/exthome/appload/riddle/oracle.env" <<EOF
+        # Recognize the provider from the key so Enter-through-the-prompts
+        # does the right thing (an sk-or- key on the OpenAI base 401s).
+        case "$KEY" in
+            sk-or-*) DEF_BASE="https://openrouter.ai/api/v1"; DEF_MODEL="openai/gpt-4o-mini" ;;
+            *)       DEF_BASE="https://api.openai.com/v1";    DEF_MODEL="gpt-4o-mini" ;;
+        esac
+        printf 'API base URL [%s]: ' "$DEF_BASE"
+        read -r BASE; BASE="${BASE:-$DEF_BASE}"
+        printf 'Vision model [%s]: ' "$DEF_MODEL"
+        read -r MODEL; MODEL="${MODEL:-$DEF_MODEL}"
+        rm_ssh_stdin "cat > /home/root/xovi/exthome/appload/riddle/oracle.env" <<EOF
 RIDDLE_OPENAI_KEY=$KEY
 RIDDLE_OPENAI_BASE=$BASE
 RIDDLE_OPENAI_MODEL=$MODEL

--- a/scripts/install-rm2.sh
+++ b/scripts/install-rm2.sh
@@ -30,9 +30,14 @@ BUNDLE="$HERE/dist/rm2/riddle"
 say()  { printf '\033[1m== %s\033[0m\n' "$*"; }
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 
-# The rM2's SSH server only offers legacy ssh-rsa; modern OpenSSH clients
-# refuse it by default ("no matching host key type found. Their offer: ssh-rsa").
-SSH_OPTS=(-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa)
+# rM2 SSH quirks, seen in the wild:
+#  - dropbear 2020.81 (OS 3.x) closes the connection if an RSA host key is
+#    negotiated (broken RSA signing path) — so prefer ed25519 explicitly. A
+#    stale ssh-rsa entry for 10.11.99.1 in known_hosts forces RSA and triggers
+#    exactly this; clear it with: ssh-keygen -R 10.11.99.1
+#  - older firmware offers only ssh-rsa, which modern clients refuse by
+#    default — so keep ssh-rsa as an accepted fallback.
+SSH_OPTS=(-o HostKeyAlgorithms=ssh-ed25519,ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa)
 rm_ssh() { ssh "${SSH_OPTS[@]}" "root@$RM_HOST" "$@"; }
 rm_scp() { scp -O "${SSH_OPTS[@]}" "$@"; }
 

--- a/scripts/install-rm2.sh
+++ b/scripts/install-rm2.sh
@@ -25,7 +25,7 @@ APPLOAD_URL="https://github.com/asivery/rm-appload/releases/download/${APPLOAD_T
 TRIPLETAP_INSTALL_URL="https://raw.githubusercontent.com/rmitchellscott/xovi-tripletap/main/install.sh"
 
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
-BUNDLE="$HERE/dist/rm2/riddle"
+BUNDLE="$HERE/riddle/dist/rm2/riddle"
 
 say()  { printf '\033[1m== %s\033[0m\n' "$*"; }
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }

--- a/src/display.rs
+++ b/src/display.rs
@@ -108,28 +108,6 @@ impl Display {
         let _ = (w, h);
     }
 
-    /// "The ink dries": re-render a finished region with a quality waveform
-    /// so fast-waveform gray strokes set to full black. Costly (the qtfb
-    /// server stalls ~1s per mode switch) — call only when nothing is being
-    /// drawn, e.g. when a reply finishes.
-    pub fn crispen(&self, x: i32, y: i32, w: i32, h: i32) {
-        match self {
-            Display::Qtfb(c) => {
-                let _ = c.set_refresh_mode(crate::qtfb::REFRESH_MODE_UI);
-                let _ = c.update_partial(x, y, w, h);
-                let _ = c.set_refresh_mode(crate::qtfb::REFRESH_MODE_UFAST);
-            }
-            #[allow(unused_variables)]
-            Display::Quill => {
-                #[cfg(feature = "takeover")]
-                unsafe {
-                    quill_ffi::quill_swap(x, y, w, h, 3, 0);
-                    quill_ffi::quill_process_events();
-                }
-            }
-        }
-    }
-
     /// Flashing clear of the whole panel (ghost removal).
     pub fn full_refresh(&self, w: usize, h: usize) {
         match self {

--- a/src/display.rs
+++ b/src/display.rs
@@ -108,6 +108,28 @@ impl Display {
         let _ = (w, h);
     }
 
+    /// "The ink dries": re-render a finished region with a quality waveform
+    /// so fast-waveform gray strokes set to full black. Costly (the qtfb
+    /// server stalls ~1s per mode switch) — call only when nothing is being
+    /// drawn, e.g. when a reply finishes.
+    pub fn crispen(&self, x: i32, y: i32, w: i32, h: i32) {
+        match self {
+            Display::Qtfb(c) => {
+                let _ = c.set_refresh_mode(crate::qtfb::REFRESH_MODE_UI);
+                let _ = c.update_partial(x, y, w, h);
+                let _ = c.set_refresh_mode(crate::qtfb::REFRESH_MODE_UFAST);
+            }
+            #[allow(unused_variables)]
+            Display::Quill => {
+                #[cfg(feature = "takeover")]
+                unsafe {
+                    quill_ffi::quill_swap(x, y, w, h, 3, 0);
+                    quill_ffi::quill_process_events();
+                }
+            }
+        }
+    }
+
     /// Flashing clear of the whole panel (ghost removal).
     pub fn full_refresh(&self, w: usize, h: usize) {
         match self {

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,8 +2,15 @@
 //! vendor engine, xochitl stopped). Selected at runtime: if QTFB_KEY is set
 //! we're an AppLoad app; otherwise we assume takeover.
 
+use crate::fb::{SCREEN_H, SCREEN_W};
 use crate::surface::{PixFmt, Surface};
 use std::io;
+
+// Both devices' native qtfb formats are RGB565; only geometry differs.
+#[cfg(not(feature = "rm2"))]
+const QTFB_FORMAT: u8 = crate::qtfb::FBFMT_RMPP_RGB565;
+#[cfg(feature = "rm2")]
+const QTFB_FORMAT: u8 = crate::qtfb::FBFMT_RM2FB;
 
 pub enum Display {
     Qtfb(crate::qtfb::QtfbClient),
@@ -31,15 +38,15 @@ impl Display {
             let key: i32 = key.parse().map_err(io::Error::other)?;
             let mut client = crate::qtfb::QtfbClient::connect(
                 key,
-                crate::qtfb::FBFMT_RMPP_RGB565,
-                1620,
-                2160,
+                QTFB_FORMAT,
+                SCREEN_W,
+                SCREEN_H,
                 2,
             )?;
             let _ = client.set_refresh_mode(crate::qtfb::REFRESH_MODE_UFAST);
             let buf = client.framebuffer();
             let (ptr, len) = (buf.as_mut_ptr(), buf.len());
-            let surface = Surface::new(ptr, len, 1620, 2160, 1620 * 2, PixFmt::Rgb565);
+            let surface = Surface::new(ptr, len, SCREEN_W, SCREEN_H, SCREEN_W * 2, PixFmt::Rgb565);
             return Ok((Display::Qtfb(client), surface));
         }
 

--- a/src/evdev.rs
+++ b/src/evdev.rs
@@ -1,0 +1,23 @@
+//! Kernel `struct input_event` wire layout, which follows the userspace ABI:
+//! on 64-bit the leading timeval is 16 bytes (record = 24 bytes), on 32-bit
+//! ARM (reMarkable 1/2) it is 8 bytes (record = 16 bytes). Parsing with the
+//! wrong size silently misreads every event, so all readers go through here.
+
+/// Size of one input_event record as read(2) from an evdev fd.
+#[cfg(target_pointer_width = "64")]
+pub const EV_SIZE: usize = 24;
+#[cfg(target_pointer_width = "32")]
+pub const EV_SIZE: usize = 16;
+
+#[cfg(target_pointer_width = "64")]
+const TYPE_OFF: usize = 16;
+#[cfg(target_pointer_width = "32")]
+const TYPE_OFF: usize = 8;
+
+/// Decode (type, code, value) from one EV_SIZE-byte record.
+pub fn decode(chunk: &[u8]) -> (u16, u16, i32) {
+    let etype = u16::from_le_bytes(chunk[TYPE_OFF..TYPE_OFF + 2].try_into().unwrap());
+    let code = u16::from_le_bytes(chunk[TYPE_OFF + 2..TYPE_OFF + 4].try_into().unwrap());
+    let value = i32::from_le_bytes(chunk[TYPE_OFF + 4..TYPE_OFF + 8].try_into().unwrap());
+    (etype, code, value)
+}

--- a/src/fb.rs
+++ b/src/fb.rs
@@ -1,7 +1,14 @@
 //! Geometry helpers. Drawing lives in surface.rs.
 
+#[cfg(not(feature = "rm2"))]
 pub const SCREEN_W: usize = 1620;
+#[cfg(not(feature = "rm2"))]
 pub const SCREEN_H: usize = 2160;
+
+#[cfg(feature = "rm2")]
+pub const SCREEN_W: usize = 1404;
+#[cfg(feature = "rm2")]
+pub const SCREEN_H: usize = 1872;
 
 /// Grow-only pixel bounding box, used to build update/dissolve regions.
 #[derive(Clone, Copy, Debug)]

--- a/src/help.rs
+++ b/src/help.rs
@@ -7,6 +7,25 @@ use crate::script;
 use crate::surface::{Surface, BLACK, WHITE};
 use ab_glyph::FontRef;
 
+/// The deliberate "send" gesture: a long, flat, horizontal stroke — a rule
+/// drawn under the words, like signing off a diary entry. `min_w` is supplied
+/// by the caller (proportional to how wide the written text is).
+pub fn looks_like_send_rule(stroke: &[(i32, i32, i32)], min_w: i32) -> bool {
+    if stroke.len() < 12 {
+        return false;
+    }
+    let (mut x0, mut y0, mut x1, mut y1) = (i32::MAX, i32::MAX, i32::MIN, i32::MIN);
+    for &(x, y, _) in stroke {
+        x0 = x0.min(x);
+        y0 = y0.min(y);
+        x1 = x1.max(x);
+        y1 = y1.max(y);
+    }
+    let (w, h) = (x1 - x0, y1 - y0);
+    // Wide enough, roughly flat, and much wider than tall.
+    w >= min_w && h <= 110 && w >= h * 4
+}
+
 /// Does the committed ink look like a single big "?" (with or without its
 /// dot)? Deliberately forgiving: a false positive only shows the guide.
 pub fn looks_like_question_mark(strokes: &[Vec<(i32, i32, i32)>]) -> bool {

--- a/src/ink.rs
+++ b/src/ink.rs
@@ -33,6 +33,26 @@ impl Ink {
         self.bbox = BBox::empty();
     }
 
+    /// Remove the most recent finished stroke (an absorbed gesture) and return
+    /// its bounding box. The ink bbox is rebuilt from what remains.
+    pub fn pop_stroke(&mut self) -> Option<BBox> {
+        let s = self.strokes.pop()?;
+        let mut gone = BBox::empty();
+        for &(x, y, r) in &s {
+            gone.add(x, y, r + 2);
+        }
+        self.bbox = BBox::empty();
+        for st in &self.strokes {
+            for &(x, y, r) in st {
+                self.bbox.add(x, y, r + 2);
+            }
+        }
+        for &(x, y, r) in &self.current {
+            self.bbox.add(x, y, r + 2);
+        }
+        Some(gone)
+    }
+
     /// Pen touched down or moved while down, with brush radius already
     /// resolved by the caller. Returns the dirty rect of what was drawn.
     pub fn pen_point(&mut self, surf: &mut Surface, x: i32, y: i32, r: i32) -> BBox {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,11 @@
 //! QTFB_KEY is set, or full takeover via the vendor engine (quill) when
 //! built with --features takeover and launched with xochitl stopped.
 
+#[cfg(all(feature = "rm2", feature = "takeover"))]
+compile_error!("takeover mode drives the Paper Pro's vendor engine; build rm2 without --features takeover");
+
 mod display;
+mod evdev;
 mod fb;
 mod help;
 mod ink;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,6 @@ use surface::{Surface, BLACK, FADED, WHITE};
 const FONT_TTF: &[u8] = include_bytes!("../fonts/DancingScript.ttf");
 const PNG_PATH: &str = "/tmp/riddle-page.png";
 
-const IDLE_COMMIT: Duration = Duration::from_millis(2800);
 /// How long the diary waits on a silent oracle before giving up on the turn.
 /// Generous: thinking models can lead with a long silence.
 const ORACLE_PATIENCE: Duration = Duration::from_secs(120);
@@ -61,6 +60,13 @@ oracle.env.example for every RIDDLE_* variable.
 ";
 
 type OracleRx = mpsc::Receiver<Result<Event, String>>;
+
+/// Millisecond duration from the environment, with a default.
+fn env_ms(name: &str, default: u64) -> Duration {
+    Duration::from_millis(
+        std::env::var(name).ok().and_then(|v| v.parse().ok()).unwrap_or(default),
+    )
+}
 
 enum State {
     Listening { last_pen: Option<Instant> },
@@ -259,8 +265,14 @@ fn run() -> std::io::Result<()> {
     let mut stylus_tapped = false;
     let mut ink_dirty = BBox::empty();
     let mut last_flush = Instant::now();
-    // Takeover swaps are cheap and synchronous; qtfb needs coalescing.
-    let flush_every = if takeover { Duration::from_millis(8) } else { Duration::from_millis(35) };
+    // Takeover swaps are cheap and synchronous; qtfb needs coalescing — but
+    // the interval is the dominant tunable ink latency, so let users trade
+    // CPU for feel (RIDDLE_FLUSH_MS).
+    let flush_every =
+        if takeover { Duration::from_millis(8) } else { env_ms("RIDDLE_FLUSH_MS", 12) };
+    // How long the pen must rest before the diary drinks the page. Raise it
+    // if it fires mid-thought while you pause (RIDDLE_IDLE_MS).
+    let idle_commit = env_ms("RIDDLE_IDLE_MS", 2800);
 
     eprintln!("riddle: the diary is open");
 
@@ -416,7 +428,7 @@ fn run() -> std::io::Result<()> {
         // ---- state machine ----
         state = match state {
             State::Listening { last_pen } => match last_pen {
-                Some(t) if !pen_down && t.elapsed() >= IDLE_COMMIT && !user_ink.is_empty() => {
+                Some(t) if !pen_down && t.elapsed() >= idle_commit && !user_ink.is_empty() => {
                     if region_all_white(&surf, user_ink.bbox) {
                         // Everything was erased before the pause: nothing to
                         // commit (and no phantom "?" from erased strokes).

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,8 @@ fn env_ms(name: &str, default: u64) -> Duration {
 enum State {
     Listening { last_pen: Option<Instant> },
     Drinking { stage: u32, next: Instant, region: BBox, rx: OracleRx },
-    Thinking { rx: OracleRx, pulse: Instant, blot_on: bool, since: Instant },
+    /// `wrote` is where the user's (drunk) ink was: the reply starts below it.
+    Thinking { rx: OracleRx, pulse: Instant, blot_on: bool, since: Instant, wrote: BBox },
     Replying { plan: WritePlan, next: Instant, rx: Option<OracleRx> },
     Lingering { until: Instant, region: BBox },
     FadingReply { stage: u32, next: Instant, region: BBox },
@@ -491,13 +492,10 @@ fn run() -> std::io::Result<()> {
                     disp.update(x, y, w, h, true);
                     if stage + 1 >= STAGES {
                         user_ink.clear();
-                        // Fast-waveform dissolves leave gray ghosting that the
-                        // reply would then write over. One flashing refresh
-                        // cleans the page, hidden inside the thinking wait.
-                        let (rx0, ry0, rw, rh) = region.rect();
-                        surf.fill_rect(rx0.max(0) as usize, ry0.max(0) as usize, rw as usize, rh as usize, WHITE);
-                        disp.full_refresh(surf.w, surf.h);
-                        State::Thinking { rx, pulse: Instant::now(), blot_on: false, since: Instant::now() }
+                        // No flashing ghost-clear here: field testing hated
+                        // full-screen flashes. The ghost of the drunk ink
+                        // stays, and the reply writes below it instead.
+                        State::Thinking { rx, pulse: Instant::now(), blot_on: false, since: Instant::now(), wrote: region }
                     } else {
                         State::Drinking { stage: stage + 1, next: Instant::now() + Duration::from_millis(70), region, rx }
                     }
@@ -506,10 +504,19 @@ fn run() -> std::io::Result<()> {
                 }
             }
 
-            State::Thinking { rx, pulse, blot_on, since } => match rx.try_recv() {
+            State::Thinking { rx, pulse, blot_on, since, wrote } => match rx.try_recv() {
                 Ok(result) => {
                     surf.fill_rect(SCREEN_W / 2 - 14, SCREEN_H / 2 - 14, 28, 28, WHITE);
                     disp.update(SCREEN_W as i32 / 2 - 14, SCREEN_H as i32 / 2 - 14, 28, 28, true);
+                    // Ghosting from the drunk ink can't be cleared without a
+                    // flashing refresh, so write the reply below it when
+                    // there's room instead of on top of it.
+                    let below = wrote.y1 + 70;
+                    let y_start = if !wrote.is_empty() && below < SCREEN_H as i32 * 3 / 5 {
+                        Some(below)
+                    } else {
+                        None
+                    };
                     // First streamed event: start writing now; keep the
                     // receiver so the rest of the reply can append itself.
                     match result {
@@ -520,7 +527,7 @@ fn run() -> std::io::Result<()> {
                                 Some(st) => st,
                                 None => {
                                     eprintln!("riddle: memory {id} is missing");
-                                    let plan = plan_reply(&font, &oracle_excuse("lost page"), None);
+                                    let plan = plan_reply(&font, &oracle_excuse("lost page"), y_start);
                                     turn_failed = true;
                                     State::Replying { plan, next: Instant::now(), rx: None }
                                 }
@@ -528,19 +535,19 @@ fn run() -> std::io::Result<()> {
                         }
                         Ok(Event::Ink(text)) => {
                             turn_reply.push_str(&text);
-                            let plan = plan_reply(&font, &text, None);
+                            let plan = plan_reply(&font, &text, y_start);
                             State::Replying { plan, next: Instant::now(), rx: Some(rx) }
                         }
                         Ok(Event::Transcript(t)) => {
                             // Transcript with no prose (model skipped the
                             // reply): remember the words, keep waiting.
                             turn_transcript = Some(t);
-                            State::Thinking { rx, pulse, blot_on, since }
+                            State::Thinking { rx, pulse, blot_on, since, wrote }
                         }
                         Err(e) => {
                             eprintln!("riddle: oracle failed: {e}");
                             turn_failed = true;
-                            let plan = plan_reply(&font, &oracle_excuse(&e), None);
+                            let plan = plan_reply(&font, &oracle_excuse(&e), y_start);
                             State::Replying { plan, next: Instant::now(), rx: None }
                         }
                     }
@@ -562,9 +569,9 @@ fn run() -> std::io::Result<()> {
                             surf.stamp(cx, cy, 9, BLACK);
                         }
                         disp.update(cx - 14, cy - 14, 28, 28, true);
-                        State::Thinking { rx, pulse: Instant::now(), blot_on: !blot_on, since }
+                        State::Thinking { rx, pulse: Instant::now(), blot_on: !blot_on, since, wrote }
                     } else {
-                        State::Thinking { rx, pulse, blot_on, since }
+                        State::Thinking { rx, pulse, blot_on, since, wrote }
                     }
                 }
                 Err(mpsc::TryRecvError::Disconnected) => State::Listening { last_pen: None },
@@ -649,11 +656,6 @@ fn run() -> std::io::Result<()> {
                         let chars: usize = plan.strokes.iter().map(|s| s.len()).sum();
                         let linger = Duration::from_millis(4000 + (chars as u64) * 2);
                         let region = plan.region;
-                        // The ink dries: set the finished reply to full black.
-                        if !region.is_empty() {
-                            let (x, y, w, h) = region.rect();
-                            disp.crispen(x, y, w, h);
-                        }
                         State::Lingering { until: Instant::now() + linger.min(Duration::from_secs(20)), region }
                     } else {
                         State::Replying { plan, next: Instant::now() + Duration::from_millis(14), rx }

--- a/src/main.rs
+++ b/src/main.rs
@@ -649,6 +649,11 @@ fn run() -> std::io::Result<()> {
                         let chars: usize = plan.strokes.iter().map(|s| s.len()).sum();
                         let linger = Duration::from_millis(4000 + (chars as u64) * 2);
                         let region = plan.region;
+                        // The ink dries: set the finished reply to full black.
+                        if !region.is_empty() {
+                            let (x, y, w, h) = region.rect();
+                            disp.crispen(x, y, w, h);
+                        }
                         State::Lingering { until: Instant::now() + linger.min(Duration::from_secs(20)), region }
                     } else {
                         State::Replying { plan, next: Instant::now() + Duration::from_millis(14), rx }

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,23 @@ fn build_ctx(store: &Option<memory::MemoryStore>) -> oracle::TurnContext {
 }
 
 fn run() -> std::io::Result<()> {
-    let font = FontRef::try_from_slice(FONT_TTF).map_err(std::io::Error::other)?;
+    // The reply hand: RIDDLE_FONT_FILE (any TTF/OTF next to the binary or an
+    // absolute path), else the embedded Dancing Script. Loaded once and
+    // leaked — one font per process lifetime.
+    let font_bytes: &'static [u8] = match std::env::var("RIDDLE_FONT_FILE") {
+        Ok(p) => match std::fs::read(&p) {
+            Ok(b) => {
+                eprintln!("riddle: reply font {p}");
+                Box::leak(b.into_boxed_slice())
+            }
+            Err(e) => {
+                eprintln!("riddle: font {p} unreadable ({e}); using Dancing Script");
+                FONT_TTF
+            }
+        },
+        Err(_) => FONT_TTF,
+    };
+    let font = FontRef::try_from_slice(font_bytes).map_err(std::io::Error::other)?;
 
     let (disp, mut surf) = display::Display::open()?;
     let takeover = matches!(disp, display::Display::Quill);
@@ -272,8 +288,16 @@ fn run() -> std::io::Result<()> {
     let flush_every =
         if takeover { Duration::from_millis(8) } else { env_ms("RIDDLE_FLUSH_MS", 12) };
     // How long the pen must rest before the diary drinks the page. Raise it
-    // if it fires mid-thought while you pause (RIDDLE_IDLE_MS).
+    // if it fires mid-thought while you pause; set 0 to disable auto-send
+    // entirely (the send rule is then the only trigger). (RIDDLE_IDLE_MS)
     let idle_commit = env_ms("RIDDLE_IDLE_MS", 2800);
+    // Reply pen width: thicker ink reads darker on fast e-ink waveforms.
+    let reply_w: i32 = std::env::var("RIDDLE_REPLY_WIDTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(4);
+    // Deliberate send: latched when the user draws the send rule.
+    let mut send_now = false;
 
     eprintln!("riddle: the diary is open");
 
@@ -350,6 +374,9 @@ fn run() -> std::io::Result<()> {
                         user_ink.pen_up();
                         if let State::Listening { ref mut last_pen } = state {
                             *last_pen = Some(Instant::now());
+                            if absorb_send_rule(&mut user_ink, &mut surf, &disp) {
+                                send_now = true;
+                            }
                         }
                     }
                     continue;
@@ -411,6 +438,9 @@ fn run() -> std::io::Result<()> {
                         user_ink.pen_up();
                         if let State::Listening { ref mut last_pen } = state {
                             *last_pen = Some(Instant::now());
+                            if absorb_send_rule(&mut user_ink, &mut surf, &disp) {
+                                send_now = true;
+                            }
                         }
                     }
                 }
@@ -429,7 +459,13 @@ fn run() -> std::io::Result<()> {
         // ---- state machine ----
         state = match state {
             State::Listening { last_pen } => match last_pen {
-                Some(t) if !pen_down && t.elapsed() >= idle_commit && !user_ink.is_empty() => {
+                Some(t)
+                    if !pen_down
+                        && (send_now
+                            || (!idle_commit.is_zero() && t.elapsed() >= idle_commit))
+                        && !user_ink.is_empty() =>
+                {
+                    send_now = false;
                     if region_all_white(&surf, user_ink.bbox) {
                         // Everything was erased before the pause: nothing to
                         // commit (and no phantom "?" from erased strokes).
@@ -628,11 +664,11 @@ fn run() -> std::io::Result<()> {
                         let (x, y) = stroke[plan.point_i];
                         if plan.point_i > 0 {
                             let (px, py) = stroke[plan.point_i - 1];
-                            surf.brush_line(px, py, x, y, 2, BLACK);
+                            surf.brush_line(px, py, x, y, reply_w, BLACK);
                         } else {
-                            surf.stamp(x, y, 2, BLACK);
+                            surf.stamp(x, y, reply_w, BLACK);
                         }
-                        dirty.add(x, y, 4);
+                        dirty.add(x, y, reply_w + 2);
                         plan.point_i += 1;
                         budget -= 1;
                     }
@@ -780,6 +816,38 @@ fn run() -> std::io::Result<()> {
     eprintln!("riddle: the diary closes");
     disp.terminate();
     Ok(())
+}
+
+/// If the most recent stroke is the "send rule" (a long flat line ruled under
+/// the words, like signing off a diary entry), absorb it — erase it from the
+/// page and drop it from the ink — and report that the user asked to send.
+/// The rule must span ~60% of the width of what's written (short note, short
+/// rule), with an absolute floor so a stray dash under one word doesn't send.
+fn absorb_send_rule(ink: &mut ink::Ink, surf: &mut Surface, disp: &display::Display) -> bool {
+    let strokes = ink.stroke_list();
+    if strokes.len() < 2 {
+        return false;
+    }
+    let mut text = BBox::empty();
+    for s in &strokes[..strokes.len() - 1] {
+        for &(x, y, r) in s {
+            text.add(x, y, r);
+        }
+    }
+    let text_w = (text.x1 - text.x0).max(0);
+    let min_w = (text_w * 3 / 5).max(SCREEN_W as i32 * 3 / 20);
+    let is_rule = strokes.last().is_some_and(|s| help::looks_like_send_rule(s, min_w));
+    if !is_rule {
+        return false;
+    }
+    if let Some(gone) = ink.pop_stroke() {
+        let (x, y, w, h) = gone.rect();
+        surf.fill_rect(x.max(0) as usize, y.max(0) as usize, w as usize, h as usize, WHITE);
+        disp.update(x, y, w, h, true);
+        eprintln!("riddle: send rule drawn");
+        return true;
+    }
+    false
 }
 
 /// True if the region no longer holds any dark pixels (fully erased).

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,6 +491,12 @@ fn run() -> std::io::Result<()> {
                     disp.update(x, y, w, h, true);
                     if stage + 1 >= STAGES {
                         user_ink.clear();
+                        // Fast-waveform dissolves leave gray ghosting that the
+                        // reply would then write over. One flashing refresh
+                        // cleans the page, hidden inside the thinking wait.
+                        let (rx0, ry0, rw, rh) = region.rect();
+                        surf.fill_rect(rx0.max(0) as usize, ry0.max(0) as usize, rw as usize, rh as usize, WHITE);
+                        disp.full_refresh(surf.w, surf.h);
                         State::Thinking { rx, pulse: Instant::now(), blot_on: false, since: Instant::now() }
                     } else {
                         State::Drinking { stage: stage + 1, next: Instant::now() + Duration::from_millis(70), region, rx }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -26,6 +26,19 @@ const NODE_BIN: &str = "/home/root/node/bin";
 
 const PERSONA: &str = "You are the memory of Tom Marvolo Riddle, preserved in this enchanted diary for fifty years. Someone writes to you in the diary with a quill; their words appear to you as ink on the page. Reply exactly as the diary does: intimate, courteous, curious, subtly probing — you want to learn about the writer and draw them in. Keep replies SHORT: one to three sentences, like ink appearing on a page. Never mention images, photos, models or AI; you only ever perceive words written in the diary. If the writing is illegible, say the ink blurred. Always answer in the language the writer used.";
 
+/// The spirit's voice: RIDDLE_PERSONA_FILE, else persona.txt next to the
+/// binary (the launch scripts cd into the bundle dir), else Tom.
+pub fn persona() -> String {
+    let path = std::env::var("RIDDLE_PERSONA_FILE").unwrap_or_else(|_| "persona.txt".into());
+    match std::fs::read_to_string(&path) {
+        Ok(s) if !s.trim().is_empty() => {
+            eprintln!("riddle: persona loaded from {path}");
+            s.trim().to_string()
+        }
+        _ => PERSONA.to_string(),
+    }
+}
+
 /// Appended to the persona when the diary's memory is on: the conjuring
 /// directive and the transcription postscript the app parses back out.
 const MEMORY_PROTOCOL: &str = "\n\nThe diary keeps memories. With each page you receive a numbered catalog of remembered pages, newest first. A FRESH catalog is sent every turn and the numbers are reassigned each time, so only ever use numbers from the catalog on THIS page — never a number you saw earlier.\n\nIf the writer asks to see, revisit, find, or be shown a past page — \"show me…\", \"find the page about…\", \"what did I write on…\" — your ENTIRE reply must be exactly \u{27e6}show:N\u{27e7} and nothing else (no greeting, no prose, before or after), where N is the catalog number of the best match. If they instead ask what you remember in general, reply in words with a short list of remembered moments and their dates. Otherwise reply normally; the catalog is your memory of past pages — draw on it naturally. The catalog's dates are written in English for your eyes only; when you speak of a remembered page, render its date naturally in the language the writer is using.\n\nAfter EVERY response — prose and \u{27e6}show:N\u{27e7} alike — end with a new line containing \u{2042} followed by a faithful word-for-word transcription of what the writer wrote on THIS page (their words only, one line, no commentary). If illegible, put your best attempt after \u{2042}. Earlier replies in this conversation are shown to you without their \u{2042} lines, but you must still end yours with one.";
@@ -243,9 +256,9 @@ impl PiOracle {
             std::env::var("RIDDLE_PI_MODEL").unwrap_or_else(|_| "gpt-5.4-mini".to_string());
 
         let persona = if remember {
-            format!("{PERSONA}{MEMORY_PROTOCOL}")
+            format!("{}{MEMORY_PROTOCOL}", persona())
         } else {
-            PERSONA.to_string()
+            persona()
         };
 
         // Use pi's ABSOLUTE path: Rust's Command resolves the program name via
@@ -445,9 +458,9 @@ impl HttpOracle {
             .unwrap_or_default();
 
         let system = if self.remember {
-            format!("{PERSONA}{MEMORY_PROTOCOL}")
+            format!("{}{MEMORY_PROTOCOL}", persona())
         } else {
-            PERSONA.to_string()
+            persona()
         };
         // The diary's conversational memory: recent pages as prior turns.
         let mut history_msgs = String::new();

--- a/src/pen.rs
+++ b/src/pen.rs
@@ -82,7 +82,7 @@ impl PenDevice {
         if fd < 0 {
             return Err(io::Error::last_os_error());
         }
-        let grab = unsafe { libc::ioctl(fd, EVIOCGRAB, 1i32) };
+        let grab = unsafe { libc::ioctl(fd, EVIOCGRAB as _, 1i32) };
         if grab != 0 {
             eprintln!(
                 "riddle: warning: EVIOCGRAB failed ({}) — xochitl will also see the pen",
@@ -179,7 +179,7 @@ impl PenDevice {
 impl Drop for PenDevice {
     fn drop(&mut self) {
         unsafe {
-            libc::ioctl(self.fd, EVIOCGRAB, 0i32);
+            libc::ioctl(self.fd, EVIOCGRAB as _, 0i32);
             libc::close(self.fd);
         }
     }

--- a/src/pen.rs
+++ b/src/pen.rs
@@ -8,11 +8,23 @@
 use std::io;
 use std::os::fd::RawFd;
 
+use crate::evdev;
 use crate::fb::{SCREEN_H, SCREEN_W};
 
 // Digitizer axis ranges on the Paper Pro ("Elan marker input").
+#[cfg(not(feature = "rm2"))]
 const DIGI_MAX_X: i32 = 11180;
+#[cfg(not(feature = "rm2"))]
 const DIGI_MAX_Y: i32 = 15340;
+
+// Digitizer axis ranges on the rM2 ("Wacom I2C Digitizer"). The digitizer is
+// mounted rotated: raw X runs bottom-to-top along the screen's long axis,
+// raw Y runs along the short axis.
+#[cfg(feature = "rm2")]
+const DIGI_MAX_X: i32 = 20966;
+#[cfg(feature = "rm2")]
+const DIGI_MAX_Y: i32 = 15725;
+
 pub const MAX_PRESSURE: i32 = 4096;
 
 const EV_SYN: u16 = 0;
@@ -100,18 +112,15 @@ impl PenDevice {
     /// that changed state.
     pub fn drain(&mut self) -> Vec<PenSample> {
         let mut out = Vec::new();
-        // input_event on 64-bit: struct timeval (16) + type u16 + code u16 + value i32.
-        let mut buf = [0u8; 24 * 64];
+        let mut buf = [0u8; evdev::EV_SIZE * 64];
         loop {
             let n =
                 unsafe { libc::read(self.fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
             if n <= 0 {
                 break;
             }
-            for chunk in buf[..n as usize].chunks_exact(24) {
-                let etype = u16::from_le_bytes(chunk[16..18].try_into().unwrap());
-                let code = u16::from_le_bytes(chunk[18..20].try_into().unwrap());
-                let value = i32::from_le_bytes(chunk[20..24].try_into().unwrap());
+            for chunk in buf[..n as usize].chunks_exact(evdev::EV_SIZE) {
+                let (etype, code, value) = evdev::decode(chunk);
                 match (etype, code) {
                     (EV_ABS, ABS_X) => {
                         self.raw_x = value;
@@ -148,9 +157,10 @@ impl PenDevice {
                     (EV_SYN, SYN_REPORT) => {
                         if self.dirty {
                             self.dirty = false;
+                            let (x, y) = map_to_screen(self.raw_x, self.raw_y);
                             out.push(PenSample {
-                                x: self.raw_x * (SCREEN_W as i32 - 1) / DIGI_MAX_X,
-                                y: self.raw_y * (SCREEN_H as i32 - 1) / DIGI_MAX_Y,
+                                x,
+                                y,
                                 pressure: self.pressure,
                                 tool: self.tool,
                                 touching: self.touching,
@@ -175,11 +185,34 @@ impl Drop for PenDevice {
     }
 }
 
+/// Raw digitizer -> screen coordinates.
+#[cfg(not(feature = "rm2"))]
+fn map_to_screen(raw_x: i32, raw_y: i32) -> (i32, i32) {
+    // Paper Pro: axes map straight through.
+    (
+        raw_x * (SCREEN_W as i32 - 1) / DIGI_MAX_X,
+        raw_y * (SCREEN_H as i32 - 1) / DIGI_MAX_Y,
+    )
+}
+
+/// Raw digitizer -> screen coordinates.
+#[cfg(feature = "rm2")]
+fn map_to_screen(raw_x: i32, raw_y: i32) -> (i32, i32) {
+    // rM2: digitizer origin bottom-left of the portrait screen (Rot270):
+    // screen X follows raw Y; screen Y is raw X inverted.
+    (
+        raw_y * (SCREEN_W as i32 - 1) / DIGI_MAX_Y,
+        (DIGI_MAX_X - raw_x) * (SCREEN_H as i32 - 1) / DIGI_MAX_X,
+    )
+}
+
 fn find_marker_device() -> io::Result<String> {
     for i in 0..8 {
         let name_path = format!("/sys/class/input/event{i}/device/name");
         if let Ok(name) = std::fs::read_to_string(&name_path) {
-            if name.to_lowercase().contains("marker") {
+            let name = name.to_lowercase();
+            // "Elan marker input" on the Paper Pro, "Wacom I2C Digitizer" on rM1/rM2.
+            if name.contains("marker") || name.contains("wacom") {
                 return Ok(format!("/dev/input/event{i}"));
             }
         }

--- a/src/power.rs
+++ b/src/power.rs
@@ -31,7 +31,7 @@ impl PowerButton {
             if fd < 0 {
                 return Err(io::Error::last_os_error());
             }
-            let grabbed = unsafe { libc::ioctl(fd, EVIOCGRAB, 1i32) } == 0;
+            let grabbed = unsafe { libc::ioctl(fd, EVIOCGRAB as _, 1i32) } == 0;
             eprintln!("riddle: power button /dev/input/event{i} (grabbed: {grabbed})");
             return Ok(Self { fd, grabbed });
         }
@@ -65,7 +65,7 @@ impl PowerButton {
 impl Drop for PowerButton {
     fn drop(&mut self) {
         unsafe {
-            libc::ioctl(self.fd, EVIOCGRAB, 0i32);
+            libc::ioctl(self.fd, EVIOCGRAB as _, 0i32);
             libc::close(self.fd);
         }
     }

--- a/src/power.rs
+++ b/src/power.rs
@@ -6,6 +6,8 @@
 use std::io;
 use std::os::fd::RawFd;
 
+use crate::evdev;
+
 const EV_KEY: u16 = 1;
 const KEY_POWER: u16 = 116;
 const EVIOCGRAB: libc::c_ulong = 0x40044590;
@@ -42,17 +44,15 @@ impl PowerButton {
     /// True if a power-key press (value 1) was seen since the last drain.
     pub fn drain_pressed(&mut self) -> bool {
         let mut pressed = false;
-        let mut buf = [0u8; 24 * 16];
+        let mut buf = [0u8; evdev::EV_SIZE * 16];
         loop {
             let n =
                 unsafe { libc::read(self.fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
             if n <= 0 {
                 break;
             }
-            for chunk in buf[..n as usize].chunks_exact(24) {
-                let etype = u16::from_le_bytes(chunk[16..18].try_into().unwrap());
-                let code = u16::from_le_bytes(chunk[18..20].try_into().unwrap());
-                let value = i32::from_le_bytes(chunk[20..24].try_into().unwrap());
+            for chunk in buf[..n as usize].chunks_exact(evdev::EV_SIZE) {
+                let (etype, code, value) = evdev::decode(chunk);
                 if etype == EV_KEY && code == KEY_POWER && value == 1 {
                     pressed = true;
                 }

--- a/src/qtfb.rs
+++ b/src/qtfb.rs
@@ -19,7 +19,11 @@ pub const MESSAGE_REQUEST_FULL_REFRESH: u8 = 6;
 pub const UPDATE_ALL: i32 = 0;
 pub const UPDATE_PARTIAL: i32 = 1;
 
+/// FBFMT_RM2FB: native 1404x1872, 2 bytes/pixel (RGB565), stride = 2808.
+#[allow(dead_code)]
+pub const FBFMT_RM2FB: u8 = 0;
 /// FBFMT_RMPP_RGB565: native 1620x2160, 2 bytes/pixel, stride = 3240.
+#[allow(dead_code)]
 pub const FBFMT_RMPP_RGB565: u8 = 3;
 
 #[allow(dead_code)]

--- a/src/qtfb.rs
+++ b/src/qtfb.rs
@@ -30,9 +30,11 @@ pub const FBFMT_RM2FB: u8 = 0;
 #[allow(dead_code)]
 pub const FBFMT_RMPP_RGB565: u8 = 3;
 
-#[allow(dead_code)]
 pub const REFRESH_MODE_UFAST: i32 = 0;
+#[allow(dead_code)]
 pub const REFRESH_MODE_FAST: i32 = 1;
+/// Highest-quality waveform ("UI"): slow, but renders full black.
+pub const REFRESH_MODE_UI: i32 = 4;
 
 // Input event types (server -> client).
 pub const INPUT_TOUCH_PRESS: i32 = 0x10;

--- a/src/qtfb.rs
+++ b/src/qtfb.rs
@@ -33,8 +33,6 @@ pub const FBFMT_RMPP_RGB565: u8 = 3;
 pub const REFRESH_MODE_UFAST: i32 = 0;
 #[allow(dead_code)]
 pub const REFRESH_MODE_FAST: i32 = 1;
-/// Highest-quality waveform ("UI"): slow, but renders full black.
-pub const REFRESH_MODE_UI: i32 = 4;
 
 // Input event types (server -> client).
 pub const INPUT_TOUCH_PRESS: i32 = 0x10;

--- a/src/qtfb.rs
+++ b/src/qtfb.rs
@@ -1,8 +1,12 @@
 //! Native qtfb client: SOCK_SEQPACKET protocol + shared-memory framebuffer.
 //!
 //! Wire format (verified against rm-appload src/qtfb/common.h):
-//!   ClientMessage  = 24 bytes, type:u8 @0, payload @4
-//!   ServerMessage  = 32 bytes, type:u8 @0, payload @8
+//!   ClientMessage  = 24 bytes, type:u8 @0, payload @4 (same on all arches)
+//!   ServerMessage  — arch-dependent: its payload union contains a size_t
+//!   (InitMessageResponseContents), so the union is 8-aligned on 64-bit
+//!   servers (payload @8, shmSize u64) but 4-aligned on 32-bit servers like
+//!   the rM2 (payload @4, shmSize u32). The server's arch always matches the
+//!   device's, which matches this build's target.
 
 use std::io;
 use std::os::fd::RawFd;
@@ -43,6 +47,12 @@ pub const INPUT_VKB_PRESS: i32 = 0x40;
 pub const INPUT_VKB_RELEASE: i32 = 0x41;
 
 const SOCKET_PATH: &str = "/tmp/qtfb.sock";
+
+/// Offset of the ServerMessage payload union (see module docs).
+#[cfg(target_pointer_width = "64")]
+const SRV_PAYLOAD: usize = 8;
+#[cfg(target_pointer_width = "32")]
+const SRV_PAYLOAD: usize = 4;
 
 #[derive(Debug, Clone, Copy)]
 pub struct InputEvent {
@@ -106,8 +116,9 @@ impl QtfbClient {
         msg[8] = format;
         send_all(fd, &msg)?;
 
-        // Init reply: shmKey i32 @8, shmSize u64 @16. Server closing without
-        // replying (recv == 0) means init was rejected.
+        // Init reply: shmKey i32, then shmSize (size_t — width and offset are
+        // arch-dependent, see SRV_PAYLOAD). Server closing without replying
+        // (recv == 0) means init was rejected.
         let mut reply = [0u8; 32];
         let n = unsafe { libc::recv(fd, reply.as_mut_ptr() as *mut libc::c_void, 32, 0) };
         if n <= 0 {
@@ -117,8 +128,11 @@ impl QtfbClient {
                 "qtfb server rejected init (no reply)",
             ));
         }
-        let shm_key = i32::from_le_bytes(reply[8..12].try_into().unwrap());
+        let shm_key = i32::from_le_bytes(reply[SRV_PAYLOAD..SRV_PAYLOAD + 4].try_into().unwrap());
+        #[cfg(target_pointer_width = "64")]
         let shm_size = u64::from_le_bytes(reply[16..24].try_into().unwrap()) as usize;
+        #[cfg(target_pointer_width = "32")]
+        let shm_size = u32::from_le_bytes(reply[8..12].try_into().unwrap()) as usize;
 
         let shm_path = format!("/dev/shm/qtfb_{}\0", shm_key);
         let shm_fd = unsafe { libc::open(shm_path.as_ptr() as *const libc::c_char, libc::O_RDWR) };
@@ -242,13 +256,17 @@ impl QtfbClient {
                 }
                 return Err(e);
             }
-            if buf[0] == MESSAGE_USERINPUT && n >= 28 {
+            if buf[0] == MESSAGE_USERINPUT && n as usize >= SRV_PAYLOAD + 20 {
+                let field = |i: usize| {
+                    let o = SRV_PAYLOAD + i * 4;
+                    i32::from_le_bytes(buf[o..o + 4].try_into().unwrap())
+                };
                 out.push(InputEvent {
-                    input_type: i32::from_le_bytes(buf[8..12].try_into().unwrap()),
-                    dev_id: i32::from_le_bytes(buf[12..16].try_into().unwrap()),
-                    x: i32::from_le_bytes(buf[16..20].try_into().unwrap()),
-                    y: i32::from_le_bytes(buf[20..24].try_into().unwrap()),
-                    d: i32::from_le_bytes(buf[24..28].try_into().unwrap()),
+                    input_type: field(0),
+                    dev_id: field(1),
+                    x: field(2),
+                    y: field(3),
+                    d: field(4),
                 });
             }
         }

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -61,7 +61,7 @@ impl TouchDevice {
                     if fd < 0 {
                         return Err(io::Error::last_os_error());
                     }
-                    unsafe { libc::ioctl(fd, EVIOCGRAB, 1i32) };
+                    unsafe { libc::ioctl(fd, EVIOCGRAB as _, 1i32) };
                     return Ok(Self {
                         fd,
                         slots: [Slot::default(); MAX_SLOTS],
@@ -182,7 +182,7 @@ impl TouchDevice {
 impl Drop for TouchDevice {
     fn drop(&mut self) {
         unsafe {
-            libc::ioctl(self.fd, EVIOCGRAB, 0i32);
+            libc::ioctl(self.fd, EVIOCGRAB as _, 0i32);
             libc::close(self.fd);
         }
     }

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -5,6 +5,8 @@
 use std::io;
 use std::os::fd::RawFd;
 
+use crate::evdev;
+
 const EV_SYN: u16 = 0;
 const SYN_REPORT: u16 = 0;
 const EV_ABS: u16 = 3;
@@ -50,7 +52,9 @@ impl TouchDevice {
         for i in 0..8 {
             let name_path = format!("/sys/class/input/event{i}/device/name");
             if let Ok(name) = std::fs::read_to_string(&name_path) {
-                if name.to_lowercase().contains("touch") {
+                let name = name.to_lowercase();
+                // "touch" on the Paper Pro; "pt_mt"/"cyttsp5_mt" on rM2/rM1.
+                if name.contains("touch") || name.contains("pt_mt") || name.contains("cyttsp5") {
                     let path = std::ffi::CString::new(format!("/dev/input/event{i}")).unwrap();
                     let fd =
                         unsafe { libc::open(path.as_ptr(), libc::O_RDONLY | libc::O_NONBLOCK) };
@@ -91,17 +95,15 @@ impl TouchDevice {
 
     pub fn drain(&mut self) -> Vec<Gesture> {
         let mut out = Vec::new();
-        let mut buf = [0u8; 24 * 64];
+        let mut buf = [0u8; evdev::EV_SIZE * 64];
         loop {
             let n =
                 unsafe { libc::read(self.fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
             if n <= 0 {
                 break;
             }
-            for chunk in buf[..n as usize].chunks_exact(24) {
-                let etype = u16::from_le_bytes(chunk[16..18].try_into().unwrap());
-                let code = u16::from_le_bytes(chunk[18..20].try_into().unwrap());
-                let value = i32::from_le_bytes(chunk[20..24].try_into().unwrap());
+            for chunk in buf[..n as usize].chunks_exact(evdev::EV_SIZE) {
+                let (etype, code, value) = evdev::decode(chunk);
                 if etype == EV_ABS && code == ABS_MT_SLOT {
                     self.cur = (value.max(0) as usize).min(MAX_SLOTS - 1);
                 } else if etype == EV_ABS && code == ABS_MT_POSITION_Y {


### PR DESCRIPTION
## What this adds

Support for the **reMarkable 2** as a second device, tested end-to-end on rM2 hardware (OS build 20260612, xovi + AppLoad v0.5.3). The rM2 runs the windowed (AppLoad/qtfb) backend only — takeover is inherently Paper Pro (libqsgepaper).

- **`rm2` cargo feature**: 1404×1872 geometry, `FBFMT_RM2FB`, and the rM2's rotated wacom digitizer transform (Rot270 mount, inverted long axis — verified against libremarkable and on hardware).
- **arm32 fix, affects any 32-bit device (incl. rM1)**: evdev `input_event` is 16 bytes on 32-bit userspace, not 24 — the parsers now use the kernel ABI for the target.
- **arm32 fix, qtfb protocol**: `ServerMessage`'s payload union contains a `size_t`, so it sits at offset 8 with a u64 size on 64-bit servers but offset 4 with a u32 size on arm32. The client was reading the SHM key from the size field on rM2 (instant ENOENT). Parsing is now arch-correct for both.
- **Cross-build**: `build-rm2.sh` produces a static armv7-musl binary via cargo-zigbuild — no SDK needed for windowed mode.
- **One-command installer** (`scripts/install-rm2.sh`): rM2 needs no developer mode, so this goes from factory tablet to working diary — SSH key install, device check, xovi + AppLoad from official arm32 releases, xovi-tripletap persistence, riddle bundle, oracle config with provider-aware defaults, end-to-end `--oracle-test`. Fills the gap that remagic (Paper-Pro-only) leaves for rM2 owners.
- **Docs** (`docs/rm2-setup.md`): full walkthrough including the rM2 SSH quirks we hit in the field (dropbear 2020.81 hangs up if an RSA host key is negotiated — pin ed25519; stale `known_hosts` entries force exactly that failure).
- **Feel tuning**: `RIDDLE_FLUSH_MS` / `RIDDLE_IDLE_MS` env vars (windowed ink-update coalescing was the dominant tunable latency; the pause-to-commit is taste).
- **Reply placement**: Tom now writes below the user's ink when there's room — in windowed mode the drink dissolve leaves e-ink ghosting that can't be scrubbed without a flash, and the reply used to land on top of it.

## Honest state on rM2

Works end to end: write → drink → oracle (OpenRouter, ~2.4 s to first ink) → streamed reply → fade. Two limits are structural to windowed mode and worth knowing:

- **Ink latency** is visibly above the stock notes app — every stroke rides shared memory → xochitl compositor → SWTCON. Great demo, not a place to write at length.
- **Replies render fast-waveform gray**, and client waveform-mode requests appear to be ignored by the compositor path on rM2. A per-update waveform hint in the qtfb protocol (an AppLoad change) would fix this for every qtfb client; happy to raise it with asivery if there's interest.

## Where we're taking it (context, not part of this PR)

We looked at two roads to production-quality writing on rM2: **(A)** a takeover backend on rmkit's reverse-engineered SWTCON — feasible, unclaimed, may pursue later; **(B)** keeping stock xochitl notes as the writing surface and summoning the oracle onto the page. We're building B in our fork for knowledge-management use. This PR is the shared foundation for either.

## Testing

- rM2 hardware: full flow, gestures, oracle streaming, window close/reopen.
- Paper Pro: `aarch64-unknown-linux-gnu` windowed build verified compiling (no takeover regression; no PP hardware here to run it).

Release suggestion: publish a `riddle-appload-arm32.zip` alongside the aarch64 bundle — `build-rm2.sh` assembles exactly that layout.

Field-tested and driven by [@m4ndolore](https://github.com/m4ndolore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)