### PR TITLE
fix: OpenAI reasoning-model compat (max_completion_tokens, empty reasoning_effort) + footprint toggle

### DIFF
--- a/riddle/oracle.env.example
+++ b/riddle/oracle.env.example
@@ -15,9 +15,12 @@ RIDDLE_OPENAI_KEY=sk-your-key-here
 # RIDDLE_OPENAI_MAX_TOKENS=2000
 
 # For reasoning models only: sent as "reasoning_effort" when set. "low" makes
-# the ink start sooner. Leave unset for non-reasoning models — some providers
-# reject the field.
+# the ink start sooner. Leave unset (or empty) for non-reasoning models —
+# some providers reject the field.
 # RIDDLE_OPENAI_REASONING=low
+
+# Stamp Tom's little footprints beside your ink while writing (off by default).
+# RIDDLE_FOOTPRINTS=on
 
 # Example: OpenRouter
 # RIDDLE_OPENAI_BASE=https://openrouter.ai/api/v1

--- a/riddle/settings.schema.json
+++ b/riddle/settings.schema.json
@@ -26,7 +26,12 @@
       "key": "RIDDLE_OPENAI_REASONING",
       "label": "Reasoning effort",
       "kind": "select",
-      "options": ["", "low", "medium", "high"],
+      "options": [
+        "",
+        "low",
+        "medium",
+        "high"
+      ],
       "help": "Only for thinking models (Gemini 3.x, o-series). Leave empty otherwise."
     },
     {
@@ -35,6 +40,16 @@
       "kind": "text",
       "placeholder": "2000",
       "help": "Runaway guard. Thinking models count hidden reasoning tokens against it — keep it roomy."
+    },
+    {
+      "key": "RIDDLE_FOOTPRINTS",
+      "label": "Footprints",
+      "kind": "select",
+      "options": [
+        "",
+        "on"
+      ],
+      "help": "Stamp Tom's little footprints beside your ink while writing. Leave empty for off."
     }
   ],
   "presets": [

--- a/riddle/src/main.rs
+++ b/riddle/src/main.rs
@@ -170,7 +170,12 @@ fn run() -> std::io::Result<()> {
     let mut stylus_tapped = false;
     let mut ink_dirty = BBox::empty();
     // Experiment: while drawing, stamp a tiny faded footprint beside the ink.
-    // This tests mixing precomposed pixel art with live pen updates.
+    // This tests mixing precomposed pixel art with live pen updates. Off by
+    // default — the stray prints read as ink blots over handwriting — and
+    // opt-in via RIDDLE_FOOTPRINTS=on (or 1/true/yes).
+    let footprints = std::env::var("RIDDLE_FOOTPRINTS")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "on" | "true" | "yes"))
+        .unwrap_or(false);
     let mut last_footstep: Option<(i32, i32)> = None;
     let mut footstep_i: u32 = 0;
     let mut last_flush = Instant::now();
@@ -264,7 +269,7 @@ fn run() -> std::io::Result<()> {
                             pen::Tool::Pen => {
                                 let r = 2 + s.pressure * 3 / pen::MAX_PRESSURE;
                                 let mut d = user_ink.pen_point(&mut surf, s.x, s.y, r);
-                                if should_stamp_footstep(last_footstep, s.x, s.y) {
+                                if footprints && should_stamp_footstep(last_footstep, s.x, s.y) {
                                     let f = draw_faded_footstep(&mut surf, s.x + 52, s.y - 38, footstep_i);
                                     d.add(f.x0, f.y0, 0);
                                     d.add(f.x1, f.y1, 0);
@@ -306,7 +311,7 @@ fn run() -> std::io::Result<()> {
                         pen_down = true;
                         let r = 2 + ev.d.clamp(0, 100) / 45;
                         let mut d = user_ink.pen_point(&mut surf, ev.x, ev.y, r);
-                        if should_stamp_footstep(last_footstep, ev.x, ev.y) {
+                        if footprints && should_stamp_footstep(last_footstep, ev.x, ev.y) {
                             let f = draw_faded_footstep(&mut surf, ev.x + 52, ev.y - 38, footstep_i);
                             d.add(f.x0, f.y0, 0);
                             d.add(f.x1, f.y1, 0);

--- a/riddle/src/oracle.rs
+++ b/riddle/src/oracle.rs
@@ -254,7 +254,12 @@ impl HttpOracle {
         // Sent as "reasoning_effort" only when set: reasoning models accept it
         // ("low" ≈ faster first ink), but some providers reject the field on
         // non-reasoning models, so it must stay out of the default request.
-        let reasoning = std::env::var("RIDDLE_OPENAI_REASONING").ok();
+        // Set-but-empty (as the settings UI writes for the "" option) means
+        // unset — sending "reasoning_effort":"" is a 400 on OpenAI.
+        let reasoning = std::env::var("RIDDLE_OPENAI_REASONING")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
         eprintln!(
             "riddle: http oracle base={base} model={model} max_tokens={max_tokens} reasoning={}",
             reasoning.as_deref().unwrap_or("-")
@@ -280,9 +285,12 @@ impl HttpOracle {
 
         thread::spawn(move || {
             // OpenAI chat-completions with a data-URI image part, streaming.
+            // The cap is sent as "max_completion_tokens": reasoning models
+            // (gpt-5.x, o-series) reject the legacy "max_tokens" outright,
+            // and every current OpenAI model accepts the new field.
             let body = format!(
                 concat!(
-                    "{{\"model\":{},\"stream\":true,\"max_tokens\":{},{}",
+                    "{{\"model\":{},\"stream\":true,\"max_completion_tokens\":{},{}",
                     "\"messages\":[",
                     "{{\"role\":\"system\",\"content\":{}}},",
                     "{{\"role\":\"user\",\"content\":[",


### PR DESCRIPTION
Fixes #3 and #7 — the two request-building bugs that make the HTTP oracle fail silently, plus the footprint toggle requested in #3.

## Changes

**1. `max_completion_tokens` instead of `max_tokens`** (`oracle.rs`)

OpenAI's reasoning models (gpt-5.x, o-series) reject the legacy `max_tokens` with HTTP 400 (`Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`), so any of those models fails on every turn. All current OpenAI models accept `max_completion_tokens`. The `RIDDLE_OPENAI_MAX_TOKENS` env var keeps its name — only the JSON field changes.

**2. Empty `RIDDLE_OPENAI_REASONING` treated as unset** (`oracle.rs`)

The settings schema's `select` includes a `""` option, so config UIs (e.g. `remagic config riddle`) write `RIDDLE_OPENAI_REASONING=` — set but empty. The code sent `"reasoning_effort":""`, which OpenAI rejects with `Unrecognized request argument supplied: reasoning_effort` on non-reasoning models. Now trimmed and filtered: empty means "don't send the field".

**3. Footprints off by default, opt-in via `RIDDLE_FOOTPRINTS=on`** (`main.rs`, `settings.schema.json`, `oracle.env.example`)

As requested in #3: the footprint experiment now only runs when `RIDDLE_FOOTPRINTS` is set to `1`/`on`/`true`/`yes`, and the toggle is exposed in the settings schema so it's flippable from the config UI without a recompile.

## Tested

On a Paper Pro (Ferrari, OS 3.27.3.0), takeover mode:
- `gpt-5.5` + `RIDDLE_OPENAI_REASONING=low` — previously 400 on every turn, now replies stream (first chunk ~2s).
- `gpt-4o` with `RIDDLE_OPENAI_REASONING=` present-but-empty — previously 400, now works.
- Footprints absent by default while writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
