### PR TITLE
feat: keep a lingering reply on the page while the writer answers

### DIFF
--- a/riddle/oracle.env.example
+++ b/riddle/oracle.env.example
@@ -15,9 +15,12 @@ RIDDLE_OPENAI_KEY=sk-your-key-here
 # RIDDLE_OPENAI_MAX_TOKENS=2000
 
 # For reasoning models only: sent as "reasoning_effort" when set. "low" makes
-# the ink start sooner. Leave unset for non-reasoning models — some providers
-# reject the field.
+# the ink start sooner. Leave unset (or empty) for non-reasoning models —
+# some providers reject the field.
 # RIDDLE_OPENAI_REASONING=low
+
+# Stamp Tom's little footprints beside your ink while writing (off by default).
+# RIDDLE_FOOTPRINTS=on
 
 # Example: OpenRouter
 # RIDDLE_OPENAI_BASE=https://openrouter.ai/api/v1

--- a/riddle/settings.schema.json
+++ b/riddle/settings.schema.json
@@ -26,7 +26,12 @@
       "key": "RIDDLE_OPENAI_REASONING",
       "label": "Reasoning effort",
       "kind": "select",
-      "options": ["", "low", "medium", "high"],
+      "options": [
+        "",
+        "low",
+        "medium",
+        "high"
+      ],
       "help": "Only for thinking models (Gemini 3.x, o-series). Leave empty otherwise."
     },
     {
@@ -35,6 +40,16 @@
       "kind": "text",
       "placeholder": "2000",
       "help": "Runaway guard. Thinking models count hidden reasoning tokens against it — keep it roomy."
+    },
+    {
+      "key": "RIDDLE_FOOTPRINTS",
+      "label": "Footprints",
+      "kind": "select",
+      "options": [
+        "",
+        "on"
+      ],
+      "help": "Stamp Tom's little footprints beside your ink while writing. Leave empty for off."
     }
   ],
   "presets": [

--- a/riddle/src/ink.rs
+++ b/riddle/src/ink.rs
@@ -4,17 +4,38 @@
 use crate::fb::BBox;
 use crate::surface::{Surface, BLACK, WHITE};
 
+/// One committed page operation, in the order the writer made it. Erases are
+/// kept as ops rather than applied destructively, so `to_png` can replay the
+/// writer's ink into a clean offscreen buffer — independent of whatever else
+/// (a lingering reply) is painted on the screen.
+enum Op {
+    /// Index into `strokes`.
+    Pen(usize),
+    /// Eraser pass as a point list (x, y, radius).
+    Erase(Vec<(i32, i32, i32)>),
+}
+
 pub struct Ink {
-    /// Finished strokes as point lists (x, y, radius).
+    /// Finished pen strokes as point lists (x, y, radius).
     strokes: Vec<Vec<(i32, i32, i32)>>,
+    /// Pen and erase ops in page order.
+    ops: Vec<Op>,
     current: Vec<(i32, i32, i32)>,
+    current_erase: Vec<(i32, i32, i32)>,
     last_erase: Option<(i32, i32)>,
     pub bbox: BBox,
 }
 
 impl Ink {
     pub fn new() -> Self {
-        Self { strokes: Vec::new(), current: Vec::new(), last_erase: None, bbox: BBox::empty() }
+        Self {
+            strokes: Vec::new(),
+            ops: Vec::new(),
+            current: Vec::new(),
+            current_erase: Vec::new(),
+            last_erase: None,
+            bbox: BBox::empty(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -28,7 +49,9 @@ impl Ink {
 
     pub fn clear(&mut self) {
         self.strokes.clear();
+        self.ops.clear();
         self.current.clear();
+        self.current_erase.clear();
         self.last_erase = None;
         self.bbox = BBox::empty();
     }
@@ -60,12 +83,17 @@ impl Ink {
         }
         dirty.add(x, y, r + 2);
         self.last_erase = Some((x, y));
+        self.current_erase.push((x, y, r));
         dirty
     }
 
     pub fn pen_up(&mut self) {
         if !self.current.is_empty() {
             self.strokes.push(std::mem::take(&mut self.current));
+            self.ops.push(Op::Pen(self.strokes.len() - 1));
+        }
+        if !self.current_erase.is_empty() {
+            self.ops.push(Op::Erase(std::mem::take(&mut self.current_erase)));
         }
         self.last_erase = None;
     }
@@ -74,6 +102,11 @@ impl Ink {
     /// Crops to the ink bounding box and box-downscales so the long side stays
     /// ≤ 800px (at least 2x): the model reads handwriting fine at that scale,
     /// and image pixels are the dominant vision-token / latency cost.
+    ///
+    /// The image is built by replaying the recorded pen/erase ops into a clean
+    /// offscreen buffer — NOT by reading the screen — so anything else on the
+    /// page (a lingering reply the writer answers underneath) never leaks into
+    /// what the oracle sees. `surf` is only consulted for the page dimensions.
     pub fn to_png(&self, surf: &Surface, path: &str) -> std::io::Result<()> {
         if self.bbox.is_empty() {
             return Err(std::io::Error::other("no ink"));
@@ -83,8 +116,22 @@ impl Ink {
         let y0 = (by - 20).max(0) as usize;
         let x1 = ((bx + bw + 20) as usize).min(surf.w);
         let y1 = ((by + bh + 20) as usize).min(surf.h);
-        let f = ((x1 - x0).max(y1 - y0)).div_ceil(800).max(2);
-        let (w, h) = ((x1 - x0) / f, (y1 - y0) / f);
+        let (cw, ch) = (x1 - x0, y1 - y0);
+
+        // Full-resolution replay of the writer's ink on a white page crop.
+        let mut page = vec![255u8; cw * ch];
+        for op in &self.ops {
+            match op {
+                Op::Pen(i) => replay(&mut page, cw, ch, x0 as i32, y0 as i32, &self.strokes[*i], 0, true),
+                Op::Erase(pts) => replay(&mut page, cw, ch, x0 as i32, y0 as i32, pts, 255, false),
+            }
+        }
+        // In-flight strokes (normally flushed by pen-up before a commit).
+        replay(&mut page, cw, ch, x0 as i32, y0 as i32, &self.current, 0, true);
+        replay(&mut page, cw, ch, x0 as i32, y0 as i32, &self.current_erase, 255, false);
+
+        let f = cw.max(ch).div_ceil(800).max(2);
+        let (w, h) = (cw / f, ch / f);
 
         let mut gray = vec![0u8; w * h];
         for oy in 0..h {
@@ -92,7 +139,7 @@ impl Ink {
                 let mut acc = 0u32;
                 for sy in 0..f {
                     for sx in 0..f {
-                        acc += surf.luma((x0 + ox * f + sx) as i32, (y0 + oy * f + sy) as i32) as u32;
+                        acc += page[(oy * f + sy) * cw + ox * f + sx] as u32;
                     }
                 }
                 gray[oy * w + ox] = (acc / (f * f) as u32) as u8;
@@ -110,6 +157,50 @@ impl Ink {
             .write_image_data(&gray)
             .map_err(std::io::Error::other)?;
         Ok(())
+    }
+}
+
+/// Replay one op's point list into a grayscale crop buffer, mirroring the
+/// on-screen geometry: first point stamps a disc; later points brush from the
+/// previous one. Pen strokes clamp radius growth exactly like `pen_point`.
+fn replay(page: &mut [u8], w: usize, h: usize, ox: i32, oy: i32, pts: &[(i32, i32, i32)], v: u8, pen: bool) {
+    let mut last: Option<(i32, i32, i32)> = None;
+    for &(x, y, r) in pts {
+        let (cx, cy) = (x - ox, y - oy);
+        match last {
+            Some((px, py, pr)) => {
+                let br = if pen { r.min(pr + 1) } else { r };
+                brush_g(page, w, h, px, py, cx, cy, br, v);
+            }
+            None => stamp_g(page, w, h, cx, cy, r, v),
+        }
+        last = Some((cx, cy, r));
+    }
+}
+
+/// `Surface::stamp` for a grayscale buffer.
+fn stamp_g(page: &mut [u8], w: usize, h: usize, cx: i32, cy: i32, r: i32, v: u8) {
+    for dy in -r..=r {
+        for dx in -r..=r {
+            if dx * dx + dy * dy <= r * r {
+                let (x, y) = (cx + dx, cy + dy);
+                if x >= 0 && y >= 0 && (x as usize) < w && (y as usize) < h {
+                    page[y as usize * w + x as usize] = v;
+                }
+            }
+        }
+    }
+}
+
+/// `Surface::brush_line` for a grayscale buffer.
+fn brush_g(page: &mut [u8], w: usize, h: usize, x0: i32, y0: i32, x1: i32, y1: i32, r: i32, v: u8) {
+    let dx = (x1 - x0).abs();
+    let dy = (y1 - y0).abs();
+    let steps = dx.max(dy).max(1);
+    for i in 0..=steps {
+        let x = x0 + (x1 - x0) * i / steps;
+        let y = y0 + (y1 - y0) * i / steps;
+        stamp_g(page, w, h, x, y, r, v);
     }
 }
 

--- a/riddle/src/main.rs
+++ b/riddle/src/main.rs
@@ -38,7 +38,9 @@ const MARGIN_X: i32 = 120;
 
 enum State {
     Listening { last_pen: Option<Instant> },
-    Drinking { stage: u32, next: Instant, region: BBox, rx: mpsc::Receiver<Result<String, String>> },
+    /// `reply`: a lingering reply the writer wrote underneath — drunk
+    /// together with the new ink (empty when there was none).
+    Drinking { stage: u32, next: Instant, region: BBox, reply: BBox, rx: mpsc::Receiver<Result<String, String>> },
     Thinking { rx: mpsc::Receiver<Result<String, String>>, pulse: Instant, blot_on: bool },
     Replying { plan: WritePlan, next: Instant, rx: Option<mpsc::Receiver<Result<String, String>>> },
     Lingering { until: Instant, region: BBox },
@@ -178,6 +180,9 @@ fn run() -> std::io::Result<()> {
         .unwrap_or(false);
     let mut last_footstep: Option<(i32, i32)> = None;
     let mut footstep_i: u32 = 0;
+    // A reply the writer started answering while it still lingered on the
+    // page: it stays visible while they write and is drunk with their ink.
+    let mut pending_reply = BBox::empty();
     let mut last_flush = Instant::now();
     // Takeover swaps are cheap and synchronous; qtfb needs coalescing.
     let flush_every = if takeover { Duration::from_millis(8) } else { Duration::from_millis(35) };
@@ -262,6 +267,16 @@ fn run() -> std::io::Result<()> {
                     }
                     continue;
                 }
+                // Pen contact while a reply lingers: keep Tom's words on the
+                // page and start inking with this same contact — the reply is
+                // remembered and drunk together with the new ink at commit.
+                if let State::Lingering { region, .. } = state {
+                    if !region.is_empty() {
+                        pending_reply.add(region.x0, region.y0, 0);
+                        pending_reply.add(region.x1, region.y1, 0);
+                    }
+                    state = State::Listening { last_pen: None };
+                }
                 match state {
                     State::Listening { ref mut last_pen } => {
                         pen_down = true;
@@ -286,9 +301,6 @@ fn run() -> std::io::Result<()> {
                         }
                         *last_pen = Some(Instant::now());
                     }
-                    State::Lingering { region, .. } => {
-                        state = State::FadingReply { stage: 0, next: Instant::now(), region };
-                    }
                     _ => {}
                 }
             }
@@ -307,6 +319,15 @@ fn run() -> std::io::Result<()> {
                 qtfb::INPUT_PEN_PRESS | qtfb::INPUT_PEN_UPDATE => {
                     stylus_on = true;
                     stylus_tapped = true;
+                    // Same as the raw-pen path: writing over a lingering
+                    // reply keeps it on the page.
+                    if let State::Lingering { region, .. } = state {
+                        if !region.is_empty() {
+                            pending_reply.add(region.x0, region.y0, 0);
+                            pending_reply.add(region.x1, region.y1, 0);
+                        }
+                        state = State::Listening { last_pen: None };
+                    }
                     if let State::Listening { ref mut last_pen } = state {
                         pen_down = true;
                         let r = 2 + ev.d.clamp(0, 100) / 45;
@@ -323,8 +344,6 @@ fn run() -> std::io::Result<()> {
                             ink_dirty.add(d.x1, d.y1, 0);
                         }
                         *last_pen = Some(Instant::now());
-                    } else if let State::Lingering { region, .. } = state {
-                        state = State::FadingReply { stage: 0, next: Instant::now(), region };
                     }
                 }
                 qtfb::INPUT_PEN_RELEASE => {
@@ -378,26 +397,35 @@ fn run() -> std::io::Result<()> {
                             let _ = tx.send(Err("no oracle".into()));
                         }
                         let region = user_ink.bbox;
-                        State::Drinking { stage: 0, next: Instant::now(), region, rx }
+                        let reply = pending_reply;
+                        pending_reply = BBox::empty();
+                        State::Drinking { stage: 0, next: Instant::now(), region, reply, rx }
                     }
                 }
                 _ => State::Listening { last_pen },
             },
 
-            State::Drinking { stage, next, region, rx } => {
+            State::Drinking { stage, next, region, reply, rx } => {
                 const STAGES: u32 = 14;
                 if Instant::now() >= next {
                     ink::dissolve_pass(&mut surf, region, stage, STAGES);
                     let (x, y, w, h) = region.rect();
                     disp.update(x, y, w, h, true);
+                    // A reply the writer answered underneath dissolves along
+                    // with their ink.
+                    if !reply.is_empty() {
+                        ink::dissolve_pass(&mut surf, reply, stage, STAGES);
+                        let (x, y, w, h) = reply.rect();
+                        disp.update(x, y, w, h, true);
+                    }
                     if stage + 1 >= STAGES {
                         user_ink.clear();
                         State::Thinking { rx, pulse: Instant::now(), blot_on: false }
                     } else {
-                        State::Drinking { stage: stage + 1, next: Instant::now() + Duration::from_millis(70), region, rx }
+                        State::Drinking { stage: stage + 1, next: Instant::now() + Duration::from_millis(70), region, reply, rx }
                     }
                 } else {
-                    State::Drinking { stage, next, region, rx }
+                    State::Drinking { stage, next, region, reply, rx }
                 }
             }
 

--- a/riddle/src/main.rs
+++ b/riddle/src/main.rs
@@ -170,7 +170,12 @@ fn run() -> std::io::Result<()> {
     let mut stylus_tapped = false;
     let mut ink_dirty = BBox::empty();
     // Experiment: while drawing, stamp a tiny faded footprint beside the ink.
-    // This tests mixing precomposed pixel art with live pen updates.
+    // This tests mixing precomposed pixel art with live pen updates. Off by
+    // default — the stray prints read as ink blots over handwriting — and
+    // opt-in via RIDDLE_FOOTPRINTS=on (or 1/true/yes).
+    let footprints = std::env::var("RIDDLE_FOOTPRINTS")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "on" | "true" | "yes"))
+        .unwrap_or(false);
     let mut last_footstep: Option<(i32, i32)> = None;
     let mut footstep_i: u32 = 0;
     let mut last_flush = Instant::now();
@@ -264,7 +269,7 @@ fn run() -> std::io::Result<()> {
                             pen::Tool::Pen => {
                                 let r = 2 + s.pressure * 3 / pen::MAX_PRESSURE;
                                 let mut d = user_ink.pen_point(&mut surf, s.x, s.y, r);
-                                if should_stamp_footstep(last_footstep, s.x, s.y) {
+                                if footprints && should_stamp_footstep(last_footstep, s.x, s.y) {
                                     let f = draw_faded_footstep(&mut surf, s.x + 52, s.y - 38, footstep_i);
                                     d.add(f.x0, f.y0, 0);
                                     d.add(f.x1, f.y1, 0);
@@ -306,7 +311,7 @@ fn run() -> std::io::Result<()> {
                         pen_down = true;
                         let r = 2 + ev.d.clamp(0, 100) / 45;
                         let mut d = user_ink.pen_point(&mut surf, ev.x, ev.y, r);
-                        if should_stamp_footstep(last_footstep, ev.x, ev.y) {
+                        if footprints && should_stamp_footstep(last_footstep, ev.x, ev.y) {
                             let f = draw_faded_footstep(&mut surf, ev.x + 52, ev.y - 38, footstep_i);
                             d.add(f.x0, f.y0, 0);
                             d.add(f.x1, f.y1, 0);

--- a/riddle/src/oracle.rs
+++ b/riddle/src/oracle.rs
@@ -254,7 +254,12 @@ impl HttpOracle {
         // Sent as "reasoning_effort" only when set: reasoning models accept it
         // ("low" ≈ faster first ink), but some providers reject the field on
         // non-reasoning models, so it must stay out of the default request.
-        let reasoning = std::env::var("RIDDLE_OPENAI_REASONING").ok();
+        // Set-but-empty (as the settings UI writes for the "" option) means
+        // unset — sending "reasoning_effort":"" is a 400 on OpenAI.
+        let reasoning = std::env::var("RIDDLE_OPENAI_REASONING")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
         eprintln!(
             "riddle: http oracle base={base} model={model} max_tokens={max_tokens} reasoning={}",
             reasoning.as_deref().unwrap_or("-")
@@ -280,9 +285,12 @@ impl HttpOracle {
 
         thread::spawn(move || {
             // OpenAI chat-completions with a data-URI image part, streaming.
+            // The cap is sent as "max_completion_tokens": reasoning models
+            // (gpt-5.x, o-series) reject the legacy "max_tokens" outright,
+            // and every current OpenAI model accepts the new field.
             let body = format!(
                 concat!(
-                    "{{\"model\":{},\"stream\":true,\"max_tokens\":{},{}",
+                    "{{\"model\":{},\"stream\":true,\"max_completion_tokens\":{},{}",
                     "\"messages\":[",
                     "{{\"role\":\"system\",\"content\":{}}},",
                     "{{\"role\":\"user\",\"content\":[",


### PR DESCRIPTION
Stacked on #8 (its commit appears here until #8 merges; rebase drops it).

## Problem

Any pen contact during `Lingering` immediately dissolved the reply — you could never write your answer while Tom's words were still on the page. Reading, then answering "blind" on an empty page breaks the conversation flow.

## Change

- The pen contact that used to dismiss a lingering reply now **starts the writer's stroke instead**; the reply stays on the page while they write (it still fades on its own if they never write).
- At commit time the old reply is drunk **together with** the writer's ink — one absorb moment — then the new reply appears (`pending_reply` tracked alongside the state machine, dissolved as a second region in `Drinking`).

## How the oracle image stays clean

This required the snapshot to stop reading the screen (a lingering reply would leak into the crop). `ink.rs` now records eraser passes as ops alongside pen strokes and **replays them in page order into a clean offscreen buffer** for `to_png`. The geometry mirrors `Surface::stamp`/`brush_line`, so the model sees the same handwriting as before — but only ever the writer's ink, even when they write directly over Tom's words.

## Tested

On a Paper Pro (Ferrari, OS 3.27.3.0, takeover mode): multiple write-over-reply turns; reply stays while writing, both dissolve together on pause, replies respond only to the writer's words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
