### PR TITLE
fix: treat set-but-empty RIDDLE_OPENAI_REASONING as unset

### DIFF
--- a/riddle/src/oracle.rs
+++ b/riddle/src/oracle.rs
@@ -420,7 +420,14 @@ impl HttpOracle {
         // Sent as "reasoning_effort" only when set: reasoning models accept it
         // ("low" ≈ faster first ink), but some providers reject the field on
         // non-reasoning models, so it must stay out of the default request.
-        let reasoning = std::env::var("RIDDLE_OPENAI_REASONING").ok();
+        // Set-but-EMPTY also means unset: config UIs writing env files (e.g.
+        // remagic's settings form, whose select includes a "" option) produce
+        // RIDDLE_OPENAI_REASONING= — and sending "reasoning_effort":"" is a
+        // 400 on OpenAI, silently killing every turn.
+        let reasoning = std::env::var("RIDDLE_OPENAI_REASONING")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
         eprintln!(
             "riddle: http oracle base={base} model={model} max_tokens={max_tokens} reasoning={}",
             reasoning.as_deref().unwrap_or("-")


### PR DESCRIPTION
Follow-up to the closed #8, reduced to the one piece v0.3.0 didn't fix.

`remagic config riddle` (and any env-file-writing config UI whose select includes the `""` option — as settings.schema.json does) writes `RIDDLE_OPENAI_REASONING=` — set but **empty**. `std::env::var(...).ok()` then yields `Some("")`, and the request carries `"reasoning_effort":""`, which OpenAI rejects with:

```
http 400: Unrecognized request argument supplied: reasoning_effort
```

…on every turn, with nothing visible on the page. Hit this in the wild on a Paper Pro configured through remagic (journal evidence in #7/#8).

One-line-ish fix: trim and filter empty, so present-but-blank behaves like absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)