### PR TITLE
Fix takeover mode on OS 3.28 (EPFramebuffer::swapBuffers ABI change)

### DIFF
--- a/quill/build.sh
+++ b/quill/build.sh
@@ -24,13 +24,13 @@ QTINC="$SDKTARGETSYSROOT/usr/include"
 $CXX -fPIC -shared -O2 \
     -I "$QTINC" -I "$QTINC/QtCore" -I "$QTINC/QtGui" \
     src/epfb.cpp src/quill_c.cpp \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -o build/libquill.so
 
 # scribble: the C1 latency demo.
 $CC -O2 src/scribble.c \
     -L build -lquill \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -lQt6Gui -lQt6Core -lstdc++ \
     -Wl,-rpath,/home/root/quill \
     -o build/scribble
@@ -38,7 +38,7 @@ $CC -O2 src/scribble.c \
 # map_demo: static full-screen map + tiny partial-update footsteps.
 $CC -O2 src/map_demo.c \
     -L build -lquill \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -lQt6Gui -lQt6Core -lstdc++ \
     -Wl,-rpath,/home/root/quill \
     -o build/map_demo
@@ -48,7 +48,7 @@ $CXX -O2 \
     -I "$QTINC" -I "$QTINC/QtCore" -I "$QTINC/QtGui" \
     src/image_demo.cpp \
     -L build -lquill \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -lQt6Gui -lQt6Core -lstdc++ \
     -Wl,-rpath,/home/root/quill \
     -o build/image_demo
@@ -58,7 +58,7 @@ $CXX -O2 \
     -I "$QTINC" -I "$QTINC/QtCore" -I "$QTINC/QtGui" \
     src/image_anim_demo.cpp \
     -L build -lquill \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -lQt6Gui -lQt6Core -lstdc++ \
     -Wl,-rpath,/home/root/quill \
     -o build/image_anim_demo
@@ -68,7 +68,7 @@ $CXX -O2 \
     -I "$QTINC" -I "$QTINC/QtCore" -I "$QTINC/QtGui" \
     src/gif_demo.cpp \
     -L build -lquill \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -lQt6Gui -lQt6Core -lstdc++ \
     -Wl,-rpath,/home/root/quill \
     -o build/gif_demo
@@ -76,7 +76,7 @@ $CXX -O2 \
 # drawlab: no-AI live drawing experiments.
 $CC -O2 src/drawlab.c \
     -L build -lquill \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -lQt6Gui -lQt6Core -lstdc++ \
     -Wl,-rpath,/home/root/quill \
     -o build/drawlab
@@ -86,7 +86,7 @@ $CXX -O2 \
     -I "$QTINC" -I "$QTINC/QtCore" -I "$QTINC/QtGui" \
     src/home.cpp \
     -L build -lquill \
-    -L vendor -lqsgepaper \
+    -L vendor -lqsgepaper -ldl \
     -lQt6Gui -lQt6Core -lstdc++ \
     -Wl,-rpath,/home/root/quill \
     -o build/home

--- a/quill/src/epframebuffer.h
+++ b/quill/src/epframebuffer.h
@@ -23,6 +23,7 @@ public:
         NoRefresh = 0,
         CompleteRefresh = 1,
     };
+    // Signature varies by OS (3.28 dropped EPContentType). quill_c resolves via dlsym.
     unsigned long swapBuffers(QRect param_1, EPContentType epct, EPScreenMode type, QFlags<EPFramebuffer::UpdateFlag> flags);
     #ifdef EPFB_INTERNAL
     static EPFramebuffer *instance();

--- a/quill/src/quill_c.cpp
+++ b/quill/src/quill_c.cpp
@@ -8,12 +8,34 @@
 #include "epframebuffer.h"
 #include <QCoreApplication>
 #include <QImage>
+#include <dlfcn.h>
 #include <cstring>
 #include <cstdio>
 
 static QCoreApplication *g_app = nullptr;
 static EPFramebuffer *g_fb = nullptr;
 static QImage *g_aux = nullptr;
+
+// OS 3.27 and earlier:
+//   swapBuffers(QRect, EPContentType, EPScreenMode, QFlags<UpdateFlag>)
+// OS 3.28+ dropped EPContentType from the QRect overload:
+//   swapBuffers(QRect, EPScreenMode, QFlags<UpdateFlag>)
+using SwapOldFn = unsigned long (*)(EPFramebuffer *, QRect, EPContentType,
+                                    EPScreenMode, EPFramebuffer::UpdateFlag);
+using SwapNewFn = unsigned long (*)(EPFramebuffer *, QRect, EPScreenMode,
+                                    EPFramebuffer::UpdateFlag);
+static SwapOldFn g_swap_old = nullptr;
+static SwapNewFn g_swap_new = nullptr;
+
+static void resolve_swap() {
+    if (g_swap_old || g_swap_new) return;
+    g_swap_new = reinterpret_cast<SwapNewFn>(dlsym(
+        RTLD_DEFAULT,
+        "_ZN13EPFramebuffer11swapBuffersE5QRect12EPScreenMode6QFlagsINS_10UpdateFlagEE"));
+    g_swap_old = reinterpret_cast<SwapOldFn>(dlsym(
+        RTLD_DEFAULT,
+        "_ZN13EPFramebuffer11swapBuffersE5QRect13EPContentType12EPScreenMode6QFlagsINS_10UpdateFlagEE"));
+}
 
 extern "C" {
 
@@ -49,11 +71,20 @@ unsigned char *quill_buffer() {
 // full_refresh != 0 forces a flashing clear of the region.
 unsigned long quill_swap(int x, int y, int w, int h, int mode, int full_refresh) {
     if (!g_fb) return 0;
-    QFlags<EPFramebuffer::UpdateFlag> flags = full_refresh
+    resolve_swap();
+    EPFramebuffer::UpdateFlag flag = full_refresh
         ? EPFramebuffer::UpdateFlag::CompleteRefresh
         : EPFramebuffer::UpdateFlag::NoRefresh;
-    return g_fb->swapBuffers(QRect(x, y, w, h), EPContentType::Mono,
-                             (EPScreenMode)mode, flags);
+    QRect rect(x, y, w, h);
+    EPScreenMode screen = static_cast<EPScreenMode>(mode);
+    if (g_swap_new) {
+        return g_swap_new(g_fb, rect, screen, flag);
+    }
+    if (g_swap_old) {
+        return g_swap_old(g_fb, rect, EPContentType::Mono, screen, flag);
+    }
+    fprintf(stderr, "quill: no EPFramebuffer::swapBuffers symbol found\n");
+    return 0;
 }
 
 void quill_process_events() {


### PR DESCRIPTION
## Summary

On **reMarkable OS 3.28+**, opening The Diary in takeover mode (via AppLoad) fails immediately and can reboot the tablet:

```
/home/root/xovi/exthome/appload/riddle/riddle: symbol lookup error:
  libquill.so: undefined symbol:
  _ZN13EPFramebuffer11swapBuffersE5QRect13EPContentType12EPScreenMode6QFlagsINS_10UpdateFlagEE
```

This is **not** an AppLoad/xovi issue — the hashtab loads fine. reMarkable changed the vendor e-paper API: the `EPFramebuffer::swapBuffers(QRect, …)` overload on 3.28 **no longer takes `EPContentType`**.

| OS | Mangled symbol (QRect overload) |
|----|----------------------------------|
| ≤3.27 | `…swapBuffersE5QRect13EPContentType12EPScreenMode…` |
| 3.28+ | `…swapBuffersE5QRect12EPScreenMode…` |

Prebuilt AppLoad bundles shipping `libquill.so` compiled against 3.27 symbols therefore crash on 3.28.

## Fix

- Resolve **both** mangled `swapBuffers` symbols at runtime via `dlsym` in `quill_c.cpp`.
- Link `-ldl` when building `libquill.so`.
- One `libquill.so` works on 3.27 and 3.28+.

## Verification

Tested on **Paper Pro (Ferrari), OS 3.28.0.162**:

- [x] Deploy rebuilt `libquill.so` into the existing v0.3.0 AppLoad bundle
- [x] Takeover launch: panel init, aux framebuffer 1620×2160, pen grab, oracle ready
- [x] Journal shows `riddle: the diary is open` — no symbol lookup error, no `rm-emergency` reboot

## Release note

After merge, **rebuild and republish the AppLoad bundle** (`./build-takeover.sh && scripts/make-bundle.sh`) so installs pick up the new `libquill.so`. Existing users on 3.28 can hot-swap only `libquill.so` as a quick fix.

Made with [Cursor](https://cursor.com)